### PR TITLE
upd : docker-worker/index.md : linux typo

### DIFF
--- a/docker-worker/index.md
+++ b/docker-worker/index.md
@@ -6,7 +6,7 @@ docson:       true
 
 # Docker Worker
 
-This worker is designed to handle tasks on linix via
+This worker is designed to handle tasks on linux via
 [docker](http://www.docker.com/).
 
 The worker being based on docker allows you to execute just about any task that


### PR DESCRIPTION
While reading, I saw this one word may want to be linux instead of linix.