### PR TITLE
Added a link to Planet Taskcluster blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,12 +27,14 @@ exclude:
 sections:
   - name: About
     links:
-    - name:  Introduction
-      url:   /index.html
-      href:  /
-    - name:  Getting Started
-      url:   /introduction/getting-started/index.html
-      href:  /introduction/getting-started/
+    - name: Introduction
+      url:  /index.html
+      href: /
+    - name: Getting Started
+      url:  /introduction/getting-started/index.html
+      href: /introduction/getting-started/
+    - name: Blog
+      url:  http://planet.mozilla.org/taskcluster
   - name: Learn
     links:
     - name: Introduction
@@ -160,8 +162,8 @@ sections:
       href: /services/hooks/
   - name: Development
     links:
-    - name:  Github Projects
-      url:   https://github.com/taskcluster
+    - name: Github Projects
+      url:  https://github.com/taskcluster
     - name: Conventions
       url:  /devel/conventions/index.html
       href: /devel/conventions/


### PR DESCRIPTION
Seems reasonable to have the Blog from our main site - e.g. like https://golang.org/ does.