### PR TITLE
Added a link to open issues and pull requests on github

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -186,3 +186,5 @@ sections:
       url:  https://github.com/taskcluster
     - name: Travis CI Status
       url:  https://travis-ci.org/taskcluster
+    - name: Open Github Issues/PRs
+      url:  https://github.com/search?utf8=%E2%9C%93&q=user%3Ataskcluster+is%3Aopen&type=Issues&ref=searchresults


### PR DESCRIPTION
We have no easy standard way to track open PRs/Issues - with this dashboard link, you quickly can keep track of what is currently open and needs attention.