### PR TITLE
Use tutorial instead of b2gtest

### DIFF
--- a/introduction/getting-started/index.md
+++ b/introduction/getting-started/index.md
@@ -19,7 +19,7 @@ What you see in the text box is a bare-bones task description, looking something
 
     { 
       provisionerId:      'aws-provisioner-v1',
-      workerType:         'b2gtest',
+      workerType:         'tutorial',
       created:            '2015-06-15Z12:00:00,
       deadline:           '2015-06-22Z12:00:00,
       payload: {

--- a/learn/authenticate/index.md
+++ b/learn/authenticate/index.md
@@ -109,8 +109,8 @@ let queue = new taskcluster.Queue({
   credentials: JSON.parse(localStorage.credentials)
 });
 
-// Query for number of pending b2gtest tasks
-let result = await queue.pendingTasks('aws-provisioner-v1', 'b2gtest');
+// Query for number of pending tutorial tasks
+let result = await queue.pendingTasks('aws-provisioner-v1', 'tutorial');
 
 // Print result
 console.log(result);

--- a/learn/create-task/index.md
+++ b/learn/create-task/index.md
@@ -51,7 +51,7 @@ let taskcluster = require('taskcluster-client');
 let task = {
   // Required properties
   provisionerId:      'aws-provisioner-v1',
-  workerType:         'b2gtest',
+  workerType:         'tutorial',
   created:            (new Date()).toJSON(),
   deadline:           taskcluster.fromNowJSON('2 days 3 hours'),
   metadata: {
@@ -83,7 +83,7 @@ keeping legacy workerTypes around until all tasks have been ported.
 Constructing a `task.payload` for docker-worker
 -----------------------------------------------
 
-The `b2gtest` workerType is a deployment of `docker-worker`, this worker
+The `tutorial` workerType is a deployment of `docker-worker`, this worker
 requires a `task.payload` that specifies which _docker image_ to load, which
 command to run and a maximum allowed runtime. You can find detailed
 documentation on this site, the schema for the `task.payload` property is
@@ -121,7 +121,7 @@ let taskcluster = require('taskcluster-client');
 
 let task = {
   provisionerId:      'aws-provisioner-v1',
-  workerType:         'b2gtest',
+  workerType:         'tutorial',
   created:            (new Date()).toJSON(),
   deadline:           taskcluster.fromNowJSON('2 days 3 hours'),
   metadata: {
@@ -205,7 +205,7 @@ global.taskId = taskId;
 // Task definition from previous example
 let task = {
   provisionerId:      'aws-provisioner-v1',
-  workerType:         'b2gtest',
+  workerType:         'tutorial',
   created:            (new Date()).toJSON(),
   deadline:           taskcluster.fromNowJSON('2 days 3 hours'),
   metadata: {

--- a/presentations/TC-101/slides/what-is-tc.md
+++ b/presentations/TC-101/slides/what-is-tc.md
@@ -39,7 +39,7 @@ A simple task:
 ```
 { 
   provisionerId:      'aws-provisioner-v1',
-  workerType:         'b2gtest',
+  workerType:         'tutorial',
   created:            '2015-06-15Z12:00:00,
   deadline:           '2015-06-22Z12:00:00,
   payload: {

--- a/presentations/TC-102/slides/tc-clients/08.md
+++ b/presentations/TC-102/slides/tc-clients/08.md
@@ -5,7 +5,7 @@ let taskcluster = require('taskcluster-client');
 
 let task = {
   provisionerId:  'aws-provisioner-v1',
-  workerType:     'b2gtest',
+  workerType:     'tutorial',
   created:        (new Date()).toJSON(),
   deadline:       taskcluster.fromNowJSON('2 days 3 hours'),
   metadata:       { ... }

--- a/presentations/scopes/index.html
+++ b/presentations/scopes/index.html
@@ -137,7 +137,7 @@ await queue.createTask(taskcluster.slugid(), {
   created:        taskcluster.fromNowJSON(),
   deadline:       taskcluster.fromNowJSON('2 days 3 hours'),
   provisionerId:  'aws-provisioner-v1',
-  workerType:     'b2gtest',
+  workerType:     'tutorial',
   payload:        {...},
   metadata:       {...}
 });
@@ -146,7 +146,7 @@ Docs it says createTask requires:
 <pre style="background: #3F3F3F">queue:create-task:&lt;provisionerId&gt;/&lt;workerType&gt;</pre>
 
 Hence, in this case we need:
-<pre style="background: #3F3F3F">queue:create-task:aws-provisioner-v1/b2gtest</pre>
+<pre style="background: #3F3F3F">queue:create-task:aws-provisioner-v1/tutorial</pre>
 Which we have by $``\text{queue:*}``$.
 </section>
 
@@ -222,7 +222,7 @@ Only works because $\text{queue:*}$ satisfies the scope given.
 // Create task
 await queue.createTask(taskcluster.slugid(), {
   provisionerId:  'aws-provisioner-v1',
-  workerType:     'b2gtest',
+  workerType:     'tutorial',
                   // Allows worker to know the creator have these scopes
   scopes:         ['index:insert-task:gecko.v1.*']
   ...
@@ -233,7 +233,7 @@ await queue.createTask(taskcluster.slugid(), {
 });
 </code></pre>
 From docs createTask now requires:
-<pre style="background: #3F3F3F">queue:create-task:aws-provisioner-v1/b2gtest
+<pre style="background: #3F3F3F">queue:create-task:aws-provisioner-v1/tutorial
 index:insert-task:gecko.v1.*</pre>
 
 Docker-worker will use auth-proxy will use the authorizedScopes
@@ -253,7 +253,7 @@ features to proxy requests.<br>
 // Create task
 await queue.createTask(taskcluster.slugid(), {
   provisionerId:  'aws-provisioner-v1',
-  workerType:     'b2gtest',
+  workerType:     'tutorial',
                   // Allows worker to know the creator have this scope
   scopes:         ['docker-worker:cache:jonasfj-*']
   ...
@@ -266,7 +266,7 @@ await queue.createTask(taskcluster.slugid(), {
 });
 </code></pre>
 From docs createTask now requires:
-<pre style="background: #3F3F3F">queue:create-task:aws-provisioner-v1/b2gtest
+<pre style="background: #3F3F3F">queue:create-task:aws-provisioner-v1/tutorial
 docker-worker:cache:jonasfj-*</pre>
 
 To mount cache worker requires:
@@ -304,7 +304,7 @@ Or it rejects the task.
   </pre>
   <p style="font-size: 60%;">
   Usually required by multiple API end-points.<br>Think of the scope
-  "assume:worker-type:aws-provisioner-v1/b2gtest" as the authority to act as a
+  "assume:worker-type:aws-provisioner-v1/tutorial" as the authority to act as a
   worker of this type.
   </p>
 </section>


### PR DESCRIPTION
This avoids privileging the b2gtest workerType, which new users do not
have access to and which anyway may go away someday.