### PR TITLE
assume:project:<project>:*

### DIFF
--- a/devel/namespaces/index.md
+++ b/devel/namespaces/index.md
@@ -118,7 +118,7 @@ Both are listed here:
    * `auth:{crud}-client:project/<project>/*` - manage project-specific clients
    * `auth:{crud}-role:project:<project>:*` - manage project-specific clients
    * `auth:{crud}-role:hook-id:project-<project>/*` - manage scopes for project-specific hooks
-   * `project:<project>:*` - all project-specific scopes
+   * `assume:project:<project>:*` - all project-specific scopes
    * `queue:get-artifact:project/<project/*` - create project-specific (non-public) artifacts
    * `hooks:modify-hook:project-<project>/*` - manage project-specific hooks
    * `secrets:<verb>:project/<project>/*` - manage project-specific secrets


### PR DESCRIPTION
Is this right? I don't know, I just suspect it is...

If it is intended to be `project:<project>:*`... hmm... actually that does make sense...

So perhaps this is wrong and it should be both?