### PR TITLE
Just a suggestion...

### DIFF
--- a/devel/namespaces/index.md
+++ b/devel/namespaces/index.md
@@ -116,7 +116,7 @@ Both are listed here:
    The scopes associated with a `project-member` role are:
 
    * `auth:{crud}-client:project/<project>/*` - manage project-specific clients
-   * `auth:{crud}-role:project:<project>:*` - manage project-specific clients
+   * `auth:{crud}-role:project:<project>/*` - manage project-specific clients
    * `auth:{crud}-role:hook-id:project-<project>/*` - manage scopes for project-specific hooks
    * `project:<project>:*` - all project-specific scopes
    * `queue:get-artifact:project/<project/*` - create project-specific (non-public) artifacts


### PR DESCRIPTION
I like to try and keep scopes on the form:
`<component>:<action>:<resource>/<subresource>/<subsubresource>/...`

We can't do it everywhere.. but this is a step in the right direction...
Also more closely aligned with what we like to do for clientId...

There isn't really anything that violates this change yet.. .except for the tutorial role.