### PR TITLE
Switched from redcarpet to kramdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,4 @@ amazing libraries and tools, upon which it is built.
 
 **Tools**,
  * [Jekyll](https://github.com/jekyll/jekyll), content generator on github pages.
- * [Pygments](http://pygments.org/), syntax highlighting on github pages.
- * [RedCarpet](https://github.com/vmg/redcarpet), markdown for github pages.
+ * [Kramdown](http://kramdown.gettalong.org/), markdown converter.

--- a/_config.yml
+++ b/_config.yml
@@ -1,14 +1,8 @@
 safe: true
 lsi: false
 highlighter: rouge
-redcarpet:
-  extensions:
-    - no_intra_emphasis
-    - fenced_code_blocks
-    - autolink
-    - tables
-    - with_toc_data
-    - strikethrough
+kramdown:
+  input: GFM
 
 exclude:
   - 'README.md'


### PR DESCRIPTION
I've done this since GitHub Pages is dropping support for Redcarpet.

See https://github.com/blog/2100-github-pages-jekyll-3

I've tested that all the extensions we had enabled in Redcarpet also work in kramdown. This is true for all except [`:autolink`](https://github.com/vmg/redcarpet/blob/v3.2.2/README.markdown#and-its-like-really-simple-to-use). However, searching our markdown files, there were no absolute urls in the text that were taking advantage of this feature, so there was no markdown to update.