### PR TITLE
Add docsearch

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,6 +21,20 @@
     <script src="/assets/bootstrap/js/bootstrap.min.js">
     </script>
 
+    <!-- Search provided by Algolia-->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.css" />
+    <link rel="stylesheet" href="/assets/docsearch.css">
+    <script src="https://cdn.jsdelivr.net/docsearch.js/1/docsearch.min.js"></script>
+    <script>
+      $(function() {
+        docsearch({
+          apiKey: '92dbc7f60d82217d93759d6e55e375b0',
+          indexName: 'taskcluster',
+          inputSelector: '#docs-search',
+        });
+      });
+    </script>
+
     {% if page.interactive %}
     <script src="/learn/bundle.js"></script>
     {% endif %}
@@ -206,6 +220,9 @@
               </ul>
             </li>
           {% endfor %}
+          <form class="navbar-form navbar-left" role="search">
+            <input type="text" id="docs-search" class="form-control" autocomplete="off" name="query" placeholder="Search Taskcluster Docs..." />
+          </form>
         </ul>
     </nav>
     <div class="container">

--- a/assets/docsearch.css
+++ b/assets/docsearch.css
@@ -1,0 +1,3 @@
+.algolia-docsearch-suggestion--category-header {
+  background-color: #000;
+}


### PR DESCRIPTION
This integrates [DocSearch](https://community.algolia.com/docsearch/documentation/). Our site will get indexed every 24 hours. We can make this fit in the navbar a bit nicer later if we want, but I think it works pretty well for now.

![docsearch](https://cloud.githubusercontent.com/assets/127521/14682950/1805ee82-06dd-11e6-92aa-ce43a674125c.gif)
