### PR TITLE
Convert http to https URLs

### DIFF
--- a/layout/head.pug
+++ b/layout/head.pug
@@ -28,6 +28,13 @@ head
     });
   if interactive
     script(src='/assets/bundle.js')
+  if docson || docref
+    script.
+      // Make sure the URL's protocol is `https`.  Lots of schema and refernce
+      // URLs are hard-coded as http, but that will cause mixed-content warnings.
+      var fixUrlProtocol = function(url) {
+        return url.replace(/^http:/, 'https:');
+      }
   if docson
     // JSON Schema Documentation
     link(rel='stylesheet', href='/assets/docson.css')
@@ -45,7 +52,7 @@ head
               }
               el.data('has-rendered', true);
               var schema = el.data('render-schema');
-              $.get(schema, function(data) {
+              $.get(fixUrlProtocol(schema), function(data) {
                 docson.doc(el, data);
               });
             });

--- a/src/assets/docref/docref.js
+++ b/src/assets/docref/docref.js
@@ -12,7 +12,7 @@ $(function() {
   $('*[data-doc-ref]').each(function() {
     var container = $(this);
     var reference = container.data('doc-ref');
-    request.get(reference).end().then(function(res) {
+    request.get(fixUrlProtocol(reference)).end().then(function(res) {
       container.html(_renderReference.render(res.body));
       $('[data-toggle="tooltip"]').tooltip();
       if (window.renderSchemas) {

--- a/src/assets/docson/docson.js
+++ b/src/assets/docson/docson.js
@@ -330,7 +330,7 @@ define(["lib/handlebars", "lib/highlight", "lib/jsonpointer", "lib/marked", "lib
                 if(this.key === "$ref") {
                     if((/^https?:\/\//).test(item)) {
                         var segments = item.split("#");
-                        var p = $.get(segments[0]).then(function(content) {
+                        var p = $.get(fixUrlProtocol(segments[0])).then(function(content) {
                             if(typeof content != "object") {
                                 try {
                                     content = JSON.parse(content);


### PR DESCRIPTION
This hacks the local copy of docson, as well as the bits of code parsing
data-doc-ref and data-doc-schema, to always load from https URLs, even
if the given URL is http.  This assumes that
https://schemas.taskcluster.net and https://references.taskcluster.net
are the same as their non-https cousins, and that all ref/schema URLs
are from one of those two sites.

---

@bstack, @jonasfj this works for me locally via ngrok, and I've deployed it to https://docs.taskcluster.net for testing.  The result seems to be working fine.