### PR TITLE
Add a task definition as a separate page

### DIFF
--- a/src/reference/platform/queue/task.md
+++ b/src/reference/platform/queue/task.md
@@ -1,0 +1,15 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+---
+
+# Task Definition
+
+The following is the JSON schema for a task definition:
+
+<div data-render-schema='http://schemas.taskcluster.net/queue/v1/create-task-request.json'></div>


### PR DESCRIPTION
I often go looking for this, and probably others don't know to find it
under the createTask API method.