### PR TITLE
create readme docs for aws-provisioner

### DIFF
--- a/layout/head.pug
+++ b/layout/head.pug
@@ -103,6 +103,8 @@ head
     script(src='/assets/superagent-promise.js')
   if docref
     script(src='/assets/docref/docref.js')
+  if docreadme
+    script(src='/assets/docreadme/docreadme.js')
   if dagred3
     script(src='/assets/d3.v3.min.js')
     script(src='/assets/dagre-d3.min.js')

--- a/src/assets/docreadme/docreadme.js
+++ b/src/assets/docreadme/docreadme.js
@@ -1,0 +1,14 @@
+/** Document Reference Utility for TaskCluster */
+
+$(function() {
+  $('*[data-doc-readme]').each(function() {
+    var container = $(this);
+    var reference = container.data('doc-readme');
+    request.get(fixUrlProtocol(reference)).end().then(function(res) {
+
+      // render to html
+      var markup = marked(res.text);
+      container.html(markup);
+    });
+  });
+});

--- a/src/reference/core/aws-provisioner/index.md
+++ b/src/reference/core/aws-provisioner/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/aws-provisioner/master/README.md'></div>


### PR DESCRIPTION
This PR implements a new attribute `data-doc-readme` for doc markdown which makes a page download an md file from a url and renders it to html.

It was only applied to the aws-provisioner main page to get some feedback. Once the approach is approved, we will move on to the rest of the items in the table of contents. 
