### PR TITLE
Add readmes for all of our services

### DIFF
--- a/src/reference/core/cors-proxy/readme.md
+++ b/src/reference/core/cors-proxy/readme.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/cors-proxy/master/README.md'></div>

--- a/src/reference/core/github/index.md
+++ b/src/reference/core/github/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-github/master/README.md'></div>

--- a/src/reference/core/hooks/index.md
+++ b/src/reference/core/hooks/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-hooks/master/README.md'></div>

--- a/src/reference/core/index.md
+++ b/src/reference/core/index.md
@@ -3,5 +3,7 @@ title: Core Services
 order: 2
 ---
 
+# Taskcluster Core Services
+
 TaskCluster core services are those which we provide for our users, but which are not fundamental to the operation of the service.
 For example, a deployment of TaskCluster that is not used to build source code would not need the github service.

--- a/src/reference/core/index/index.md
+++ b/src/reference/core/index/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-index/master/README.md'></div>

--- a/src/reference/core/login/index.md
+++ b/src/reference/core/login/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-login/master/README.md'></div>

--- a/src/reference/core/purge-cache/index.md
+++ b/src/reference/core/purge-cache/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-purge-cache/master/README.md'></div>

--- a/src/reference/core/secrets/index.md
+++ b/src/reference/core/secrets/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-secrets/master/README.md'></div>

--- a/src/reference/index.md
+++ b/src/reference/index.md
@@ -2,6 +2,8 @@
 title: Reference
 ---
 
+# Taskcluster Reference
+
 This portion of the TaskCluster documentation contains reference material.
 Consult the [manual](/manual) for the background to this information.
 

--- a/src/reference/platform/auth/index.md
+++ b/src/reference/platform/auth/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-auth/master/README.md'></div>

--- a/src/reference/platform/index.md
+++ b/src/reference/platform/index.md
@@ -3,5 +3,7 @@ title: TaskCluster Platform
 order: 1
 ---
 
+# Taskcluster Platform Services
+
 The TaskCluster Platform encompasses the services required to execute tasks.
 Any deployment of TaskCluster must include these services.

--- a/src/reference/platform/queue/index.md
+++ b/src/reference/platform/queue/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-queue/master/README.md'></div>

--- a/src/reference/platform/scheduler/index.md
+++ b/src/reference/platform/scheduler/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/task-graph-scheduler/master/README.md'></div>


### PR DESCRIPTION
This just extends your work to the rest of our services. cors-proxy already had an `index.md` so I just put it in `readme.md`.