### PR TITLE
Structure tutorial next-steps

### DIFF
--- a/layout/followup.pug
+++ b/layout/followup.pug
@@ -1,0 +1,9 @@
+if followup
+  div.followup
+    hr
+    h2 Next Steps
+      if followup.subtext
+        small  #{followup.subtext}
+    .list-group
+      each title, link in followup.links
+        a(href=link, class='list-group-item')= title

--- a/layout/layout.pug
+++ b/layout/layout.pug
@@ -8,5 +8,6 @@ html(lang='en')
       .row
         section.col-md-9.content
           | !{content}
+          include followup.pug
         aside.col-md-3
           include sidebar.pug

--- a/src/tutorial/async-javascript.md
+++ b/src/tutorial/async-javascript.md
@@ -2,6 +2,9 @@
 layout:       default
 class:        markdown
 interactive:  true
+followup:
+  links:
+    authenticate: Authenticate
 ---
 
 Modern `async` Javascript
@@ -394,7 +397,3 @@ And the following **modules from npm**:
 Feel free to request additional modules to be added, or versions to be upgraded.
 The intent is to supply modules that are useful in tutorials and for quick
 one-off experiments.
-
-# Next Steps
-
-* [Authenticate](authenticate)

--- a/src/tutorial/authenticate.md
+++ b/src/tutorial/authenticate.md
@@ -3,6 +3,9 @@ layout:             default
 class:              markdown
 sequence_diagrams:  true
 interactive:        true
+followup:
+  links:
+    create-task-via-api: Create a task with createTask
 ---
 
 Authenticating to TaskCluster
@@ -121,7 +124,3 @@ console.log(result);
 
 Don't worry if the number of pending tasks is zero; that is the case most of
 the time, as we aim to process tasks as soon as they arrive.
-
-# Next Steps
-
-* [Create a task with createTask](create-task-via-api)

--- a/src/tutorial/create-task-via-api.md
+++ b/src/tutorial/create-task-via-api.md
@@ -3,6 +3,9 @@ layout:       default
 class:        markdown
 docson:       true
 interactive:  true
+followup:
+  links:
+    '/reference': API documentation for all TaskCluster services
 ---
 
 Creating A Task With createTask
@@ -414,8 +417,3 @@ If the artifact was private (ie. didn't start with `public/`) we could have
 constructed the `queue` object with credentials and used the auxiliary
 method `queue.buildSignedUrl` which works like `queue.buildUrl`, with the only
 difference that includes a signature in the query-string for the URL.
-
-# Next Steps
-
- * The [reference component](/reference) contains links to the API
-   documentation for all TaskCluster services.

--- a/src/tutorial/gecko-decision-task.md
+++ b/src/tutorial/gecko-decision-task.md
@@ -1,3 +1,9 @@
+---
+followup:
+  links:
+    gecko-task-graph: How is the task-graph generated?
+---
+
 # Gecko Decision Task
 
 Upon detecting a push to a supported Mercurial repository, TaskCluster reads [`.taskcluster.yml`](https://dxr.mozilla.org/mozilla-central/source/.taskcluster.yml) from the root directory of the repository, in the revision just pushed.
@@ -11,7 +17,3 @@ This pattern occurs even for a try push.
 That means you can modify how the decision task is invoked, or even what the decision task does, in a try push!
 
 You can find a link to the latest mozilla-central decision task in [the TaskCluster index](https://tools.taskcluster.net/index/#gecko.v2.mozilla-central.latest.firefox/gecko.v2.mozilla-central.latest.firefox.decision).
-
-# Next Steps
-
- * [How is the task-graph generated?](gecko-task-graph)

--- a/src/tutorial/gecko-task-graph.md
+++ b/src/tutorial/gecko-task-graph.md
@@ -1,3 +1,10 @@
+---
+followup:
+  links:
+    gecko-try-pushes: (TODO) How do try pushes work?
+    gecko-new-job: I want to add a new job
+---
+
 # Gecko Task Graph Creation
 
 The decision task is responsible for creating the "task graph".
@@ -14,8 +21,3 @@ The task-graph generation process is well-documented in the [Gecko Documentation
 Try pushes are handled the same way.
 The in-tree task-graph generation code parses the try commit message and uses the result to determine which tasks, out of the full task graph that might be run on an integration branch, should be performed for the try push.
 This means that you can easily [add entirely new tasks](gecko-new-job) (a new test suite, a new platform, etc.) to the tree and test them with a try push.
-
-# Next Steps
-
- * [How do try pushes work?](gecko-try-pushes)
- * [I want to add a new job](gecko-new-job)

--- a/src/tutorial/gecko-tasks.md
+++ b/src/tutorial/gecko-tasks.md
@@ -1,3 +1,10 @@
+---
+followup:
+  links:
+    gecko-decision-task: How is the decision task defined?
+    gecko-task-graph: How is the task-graph generated?
+    gecko-docker-images: How are the docker images created?
+---
 # Gecko and TaskCluster
 
 When a developer pushes to a Gecko repository, a long chain of events begins:
@@ -10,11 +17,6 @@ When a developer pushes to a Gecko repository, a long chain of events begins:
  * The result of each task is sent to [TreeHerder](https://treeherder.mozilla.org) where developers and sheriffs can track the status of the push.
  * The outputs from each task -- log files, Firefox installers, and so on -- appear attached to each task (viewable in the [Task Inspector](https://tools.taskcluster.net/task-inspector/)) when it completes.
 
-# Next Steps
+Due to its "self-service" design, very little of this process is actually part of TaskCluster, so we provide only a brief overview and some pointers.
 
-Due to its "self-service" desgn, very little of this process is actually part of TaskCluster, so we provide only a brief overview and some pointers.
 TaskCluster provides a small bit of glue ([mozilla-taskcluster](/manual/vcs/mozilla-taskcluster)) to create the decision task and some more ([taskcluster-treeherder](/reference/core/treeherder)) to communicate with treeherder, but the task graph itself is defined entirely in-tree.
-
- * [How is the decision task defined?](gecko-decision-task)
- * [How is the task-graph generated?](gecko-task-graph)
- * [I want to add a new job](gecko-new-job)

--- a/src/tutorial/hack-tc.md
+++ b/src/tutorial/hack-tc.md
@@ -1,3 +1,8 @@
+---
+followup:
+  links:
+    reviews: Submitting changes of TaskCluster itself for review
+---
 # Hacking on TaskCluster
 
 Hacking on TaskCluster is really easy. Head over to the [TaskCluster GitHub
@@ -7,6 +12,3 @@ want to contribute to and feel free to make pull requests.
 The code base uses ES6 syntax and features like promises and async.
 [This page](async-javascript) should provide the required background if you
 don’t have it already.
-
-# Next Steps
-* [Submitting changes of TaskCluster itself for review](reviews)

--- a/src/tutorial/hello-world.md
+++ b/src/tutorial/hello-world.md
@@ -1,3 +1,11 @@
+---
+followup:
+  subtext: Digging Deeper
+  links:
+    finding-tasks: I want to look at some real tasks
+    interactive: I want to know how the tools site works
+    gecko-tasks: I'm a Firefox/Gecko developer - How do my commits get built?
+---
 # Hello, World
 
 Let's start by seeing TaskCluster in action.
@@ -61,11 +69,3 @@ You've run your first task!
 # See Also
 
  * ["TaskCluster Hello World" video by mrrrgn and dustin](https://vreplay.mozilla.com/replay/showRecordingExternal.html?key=7AvN2iczQYcI3lY)
-
-# Next Steps
-
-OK, that was pretty simple -- but I can think of easier ways to print "hello world".  What's next?
-
- * [I want to look at some real tasks](finding-tasks)
- * [I want to know how the tools site works](interactive)
- * [I'm a Firefox / Gecko developer - how do my commits get built?](gecko-tasks)

--- a/src/tutorial/index.md
+++ b/src/tutorial/index.md
@@ -1,3 +1,15 @@
+---
+followup:
+  subtext: How do you want to use TaskCluster?
+  links:
+    tutorial/what-is-tc: I'm not sure - what is it?
+    tutorial/hello-world: I want to run a task manually in TaskCluster
+    tutorial/gecko-tasks: I'm a Firefox / Gecko developer and I want to change builds or tests
+    tutorial/debug-task: A task is failing and I want to debug it
+    tutorial/interactive: I want to work with the TaskCluster APIs
+    tutorial/hack-tc: I want to hack on TaskCluster itself
+---
+
 # TaskCluster
 
 Welcome to TaskCluster!
@@ -10,16 +22,7 @@ information.
 If you want a more comprehensive description of TaskCluster's design and
 operation, see the manual portion of this documentation.
 
-# Next Steps
-
 How do you want to use TaskCluster?
-
- * [I'm not sure - what is it??](tutorial/what-is-tc)
- * [I want to run a task manually in TaskCluster](tutorial/hello-world)
- * [I'm a Firefox / Gecko developer and I want to change builds or tests](tutorial/gecko-tasks)
- * [A task is failing and I want to debug it](tutorial/debug-task)
- * [I want to work with the TaskCluster APIs](tutorial/interactive)
- * [I want to hack on TaskCluster itself](tutorial/hack-tc)
 
 ## Patches Welcome!
 

--- a/src/tutorial/interactive.md
+++ b/src/tutorial/interactive.md
@@ -1,6 +1,10 @@
 ---
 layout:       default
 class:        markdown
+followup:
+  links:
+    async-javascript: Modern Async Javascript
+    authenticate: Authenticate
 ---
 
 Interactive API Tutorial
@@ -28,8 +32,3 @@ other things.
 Note: the graphical TaskCluster tools on `tools.taskcluster.net` are all
 written in client-side Javascript. In fact, the entire site is a static
 web-site hosted on a CDN.
-
-# Next Steps
-
-* [Modern Async JavaScript](async-javascript)
-* [Authenticate](authenticate)

--- a/src/tutorial/what-is-tc.md
+++ b/src/tutorial/what-is-tc.md
@@ -1,3 +1,8 @@
+---
+followup:
+  links:
+    hello-world: Create a task to see TaskCluster in action!
+---
 # What is TaskCluster
 
 *TaskCluster* is a set of components that manages task queuing, scheduling,
@@ -29,7 +34,3 @@ While we have built some Mozilla-specific integrations, the platform and many of
 However, the platform is not presently designed to be easily redeployed.
 While it is by no means impossible to set up a second instance of TaskCluster outside of Mozilla, neither is it a turnkey installation.
 We hope to address this soon, once we have demonstrated the usefulness of the platform.
-
-# Next Steps
-
-Try creating a [hello world](hello-world) task to see TaskCluster in action.


### PR DESCRIPTION
This was motivated by me wanting the links at the bottom of the pages to be styled a bit differently, but I think the new way the links are defined is a pretty nice side-effect of this. I'm 100% up for changing some bit of how this works/looks.

Right now the links are on the [bottom of the page where they were before](https://imbstack.keybase.pub/bottom-next-steps.mov), but perhaps [the sidebar](https://imbstack.keybase.pub/sidebar-next-steps.mov) is a better place for them?

