### PR TITLE
Added API docs for taskcluster-notify

### DIFF
--- a/src/reference/core/notify/api-docs.md
+++ b/src/reference/core/notify/api-docs.md
@@ -1,0 +1,11 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+---
+
+<div data-doc-ref='http://references.taskcluster.net/notify/v1/api.json'></div>

--- a/src/reference/core/notify/index.md
+++ b/src/reference/core/notify/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-notify/master/README.md'></div>


### PR DESCRIPTION
Since http://references.taskcluster.net/manifest.json now includes Notify service, I added API reference to docs site.

If we're not ready to have docs on this service yet, we probably shouldn't add it to manifest.json.