### PR TITLE
add more scheduler redirects

### DIFF
--- a/redirects.yml
+++ b/redirects.yml
@@ -43,6 +43,12 @@
 /scheduler/events/: /reference/platform/scheduler/exchanges
 /scheduler: /manual/tasks/scheduler
 /scheduler/: /manual/tasks/scheduler
+/services/scheduler/api-docs: /reference/platform/scheduler/api-docs
+/services/scheduler/api-docs/: /reference/platform/scheduler/api-docs
+/services/scheduler/events: /reference/platform/scheduler/exchanges
+/services/scheduler/events/: /reference/platform/scheduler/exchanges
+/services/scheduler: /manual/tasks/scheduler
+/services/scheduler/: /manual/tasks/scheduler
 /services/cors-proxy: /reference/core/cors-proxy
 /services/cors-proxy/: /reference/core/cors-proxy
 /services/index: /reference/core/index/api-docs


### PR DESCRIPTION
I'm not sure these URLs ever worked, but something once pointed to them,
so let's give users the content they came for.