### PR TITLE
Update a few inconsistent links in MD files.

### DIFF
--- a/src/manual/apis/roles.md
+++ b/src/manual/apis/roles.md
@@ -45,7 +45,7 @@ In practice, roles are used in a few ways within TaskCluster:
  * As a way to configure scopes for TaskCluster resources like hooks or worker types
  * As a scope allowing the bearer to "assume" the named role.
 
-See the [namespaces](../../devel/namespaces/) document for more information.
+See the [namespaces](/manual/devel/namespaces) document for more information.
 
 The set of defined roles is visible in the [Roles
 tool](http://tools.taskcluster.net/auth/roles/).  This interface helpfully

--- a/src/manual/execution/workers/index.md
+++ b/src/manual/execution/workers/index.md
@@ -24,6 +24,6 @@ Queue downtime for the roll out of a new worker. It also means one-off workers
 can be written for one-off jobs, if required.
 
 For the interaction between workers and the Queue, see [Queue - Worker
-Interaction](/manual/tasks/worker-interaction/).
+Interaction](/manual/tasks/worker-interaction).
 
 For specific classes of workers, see the nested subsections.

--- a/src/tutorial/authenticate.md
+++ b/src/tutorial/authenticate.md
@@ -12,7 +12,7 @@ Authenticating to TaskCluster
 =============================
 
 TaskCluster uses its own kind of "credentials" to [authenticate API
-requests](/manual/apis/).  These credentials can come from a variety of
+requests](/manual/apis).  These credentials can come from a variety of
 sources, but in this section we will use [temporary
 credentials](/manual/apis/temporary-credentials) issued by the TaskCluster
 login service.


### PR DESCRIPTION
There are 3 cases of links in the markdown links containing traling slashes. In
2 cases this results in broken links:
- tutorial/authenticate.md has a broken link to APIs
- manual/execution/workers/index.md has a broken link to worker interaction.

In another case this did not result in a broken link:
- manual/apis/roles.md links to namespaces.

It appears pages inside devel/ will redirect if issued at <base>/devel/page.
Which baffles me. However I figured this link should also be made consistent
with the absolute addressing used in the docs, so I've updated it.