### PR TITLE
Fix trailing slash on link in tutorial/hellow-world.md

### DIFF
--- a/src/tutorial/hello-world.md
+++ b/src/tutorial/hello-world.md
@@ -48,7 +48,7 @@ Submit the task, and click the resulting task ID to load the task inspector whil
 The fields in the task description are explained in greater detail throughout the rest of this documentation, but briefly:
 
  * `provisionerId` identifies the TaskCluster provisioner responsible for the compute resources that will execute the task.
-   In this case, it is the [AWS Provisioner](/services/aws-provisioner/), which runs its tasks on Amazon EC2 instances using Docker.
+   In this case, it is the [AWS Provisioner](/services/aws-provisioner), which runs its tasks on Amazon EC2 instances using Docker.
  * `workerType` is a parameter specific to the AWS provisioner which identifies the pool of EC2 resources within which the task should be executed.
    Pools may use different EC2 instance types, AMIs, etc.
    In this case, we are using a worker type dedicated to running tasks in this tutorial.


### PR DESCRIPTION
This fixes a link which is broken due to having a traling slash, same as last
commits, but a case that I missed.