### PR TITLE
Add README docs for more services

### DIFF
--- a/src/reference/core/cloud-mirror/index.md
+++ b/src/reference/core/cloud-mirror/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/cloud-mirror/master/README.md'></div>

--- a/src/reference/core/diagnostics/index.md
+++ b/src/reference/core/diagnostics/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-diagnostics/master/README.md'></div>

--- a/src/reference/core/events/index.md
+++ b/src/reference/core/events/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-events/master/README.md'></div>

--- a/src/reference/core/stats-collector/index.md
+++ b/src/reference/core/stats-collector/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/taskcluster-stats-collector/master/README.md'></div>

--- a/src/reference/core/statsum/index.md
+++ b/src/reference/core/statsum/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/statsum/master/README.md'></div>


### PR DESCRIPTION
Ideally this would become our authoritative list of services.

I realize this is redundant with @kristelteng's work, but it's an easy thing to merge in the interim.