### PR TITLE
remove aws-sdk-promise

### DIFF
--- a/main.js
+++ b/main.js
@@ -216,7 +216,6 @@ require("promise");
 require("url-join");
 require("bluebird");
 require("aws-sdk");
-require("aws-sdk-promise");
 require("js-yaml");
 require("xml2js");
 require("docker-exec-websocket-server");

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "aws-sdk": "^2.3.8",
-    "aws-sdk-promise": "^0.0.2",
     "babel-core": "^5.6.15",
     "babel-runtime": "^5.6.15",
     "bluebird": "^2.9.32",

--- a/src/tutorial/async-javascript.md
+++ b/src/tutorial/async-javascript.md
@@ -392,7 +392,7 @@ We have embedded the following **standard node modules** from browserify:
 And the following **modules from npm**:
 `taskcluster-client`, `slugid`, `lodash`, `uuid`, `superagent`,
 `superagent-promise`, `debug`, `hawk`, `promise`, `url-join`, `bluebird`,
-`aws-sdk`, `aws-sdk-promise`, `js-yaml`, `xml2js`, `docker-exec-websocket-server`.
+`aws-sdk`, `js-yaml`, `xml2js`, `docker-exec-websocket-server`.
 
 Feel free to request additional modules to be added, or versions to be upgraded.
 The intent is to supply modules that are useful in tutorials and for quick


### PR DESCRIPTION
It seems this was just included for the sake of the in-browser environment.  The gulp upload doesn't use it (or any of our own code that might be confused by its monkeypatching)