### PR TITLE
Bug 1309713: add more links to gecko docs

### DIFF
--- a/redirects.yml
+++ b/redirects.yml
@@ -71,8 +71,3 @@
 /workers/: /manual/execution/workers
 /workers/taskcluster-worker: /manual/execution/workers/taskcluster-worker
 /workers/taskcluster-worker/: /manual/execution/workers/taskcluster-worker
-
-# handle a trailing slash here, since I type it all the time
-/reference/: /reference
-/manual/: /manual
-/tutorial/: /tutorial

--- a/src/tutorial/gecko-task-graph-howto.md
+++ b/src/tutorial/gecko-task-graph-howto.md
@@ -1,0 +1,8 @@
+# Changing the Task Graph
+
+We know that task-graph configuration is not an area of expertise for most Firefox developers.
+So the task-graph generation machinery is designed to make common changes easy.
+
+Please see the [Gecko Documentation » TaskCluster Task-Graph Generation » How Tos](http://gecko.readthedocs.io/en/latest/taskcluster/taskcluster/how-tos.html) for some general help on modifying the task graph and, more importantly, recipes for some of the more common modifications.
+
+The TaskCluster team also stands ready to help, if you need additional assistance.

--- a/src/tutorial/gecko-task-graph.md
+++ b/src/tutorial/gecko-task-graph.md
@@ -2,6 +2,7 @@
 followup:
   links:
     gecko-new-job: I want to add a new job
+    gecko-task-graph-howto: I want to change something else
 ---
 
 # Gecko Task Graph Creation


### PR DESCRIPTION
The redirects were the thing I added to try to get docs to regenerate yesterday.  They work fine on S3, but cause redirect loops with `gulp webserver`, so I guess we can leave them out.