### PR TITLE
Fix a typo in the header of output schemas

### DIFF
--- a/layout/reference.pug
+++ b/layout/reference.pug
@@ -132,7 +132,7 @@ each entry in entries.filter(function(entry) { return entry.type === 'function';
     h3 Request Payload
     div(data-render-schema= entry.input)
   if entry.output
-    h3 Request Payload
+    h3 Response
     div(data-render-schema= entry.output)
   br
 


### PR DESCRIPTION
I believe there's a typo here. The header for output schemas should be "Response" instead of "Request Payload", which was probably overlooked during the copy-paste.

Correct me if I missed anything.