### PR TITLE
Rudimentary toggle-able mobile sidebar

### DIFF
--- a/layout/layout.pug
+++ b/layout/layout.pug
@@ -6,7 +6,10 @@ html(lang='en')
     if nav
       #content.container-fluid
         .row
-          aside.col-md-3.hidden-xs.hidden-sm
+          .col-xs-12.hidden-md.hidden-lg
+            button.btn.btn-primary(type="button", data-toggle="collapse", data-target="#sidebar") Menu
+            hr
+          aside#sidebar.col-md-3.col-xs-12.hidden-sm.hidden-xs
             include sidebar.pug
           section#content.col-md-9
             if title

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -171,6 +171,18 @@ pre.json-schema {
   text-align: center;
 }
 
+@media screen and (max-width: 767px) {
+  #sidebar.collapse.in {
+    display: block !important;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  #sidebar.collapse, #sidebar.collapse.in {
+    display: block !important;
+  }
+}
+
 ul.pager {
   font-size: 13px;
 }


### PR DESCRIPTION
Right now visiting any pages which have a sidebar navigation on mobile leaves you in a dead end; you can view the page you navigate to, but cannot choose where to go next as the sidebar has been hidden on mobile to keep from cluttering the top of the page.

To overcome this, I just added a simple "Menu" button at the top of the page on mobile to toggle the sidebar. The sidebar will continue to be visible on desktop, and mobile can open the menu as desired.