### PR TITLE
Add a manual page for hooks, and decision tasks

### DIFF
--- a/src/manual/integrations/hooks.md
+++ b/src/manual/integrations/hooks.md
@@ -1,0 +1,45 @@
+---
+title: Hooks
+order: 50
+---
+
+The [Hooks service](/reference/core/hooks/) is responsible for creating
+pre-defined tasks in response to external events.
+
+At the moment, it only supports creating tasks at particular times, but it will
+soon be expanded to support triggering tasks from arbitrary web hooks and/or
+pulse messages.
+
+## Using Hooks
+
+Hooks are named with a `hookGroupId` and a `hookId`. The group IDs follow a
+pattern given in the [namespaces document](/manual/devel/namespaces). The
+`hookId` is arbitrary, although it is a good idea to think carefully about the
+names and use long, hierarchical names.
+
+The scopes available to a hook are given by a role. This allows separation of
+hook management from scope management, and the full generality of scope
+expansion. The role for a hook is named `hook-id:<hookGroupId>/<hookId>`. The
+role must include all of the scopes required to create the task, including
+`queue:create-task:<provisionerId>/<workerType>`.
+
+The scopes actually used by the hook's task are, of course, defined in
+`task.scopes`, which must be satisfied by the hook's role. These need not
+include `queue:create-task:<provisionerId>/<workerType>` unless the task will
+be creating more tasks (for example, a [decision task](/manual/tasks/decision)).
+
+## Advice
+
+Hooks are not easy to manage directly, and exist far from the rest of the
+infrastructure for your project. Try to avoid embedding too much detail into
+the hook definition.
+
+For simple work (for example, a periodic cache refresh), create a shell script
+in your code repository, and write a hook that will check out the latest source
+and run that script. Then any modifications to the cache-refresh process can be
+handled using your usual development processes, instead of an update in the
+hooks API.
+
+For more complex purposes, invoke a [decision task](/manual/tasks/decision)
+thad runs within a source checkout and draws the details of what to achieve out
+of that source checkout.

--- a/src/manual/tasks/decision.md
+++ b/src/manual/tasks/decision.md
@@ -1,0 +1,55 @@
+---
+title: Decision Tasks
+order: 90
+---
+
+Useful work often requires more than one task. For example, new source code
+might be built on several platforms, or slow tests might be split up to run in
+parallel.
+
+TaskCluster's developers and users have established a convention for
+accomplishing this, called a "decision task". This is a single task which runs
+first, and creates all of the required tasks directly by calling the
+`queue.createTask` endpoint.
+
+This has a number of advantages over other options:
+
+ * The set of tasks to run can be specified in the same source tree as the code
+   being built, allowing unlimited flexibility in what runs and how.
+ * Several event sources can all create similar decision tasks. For example, a
+   push, a new pull request, and a "nightly build" hook can all create decision
+   tasks with only slightly different parameters, avoiding repetition of complex
+   task-definition logic in all of the related services.
+
+The disadvatage being TaskCluster does not provide an easy way to design decision
+tasks. The Gecko (Firefox) project has a sophisticated implementation, but it
+is not designed to be used outside of the Gecko source tree. Other projects
+are left to implement decision tasks on their own.
+
+We on the TaskCluster team would like to remedy this shortcoming, but it is not
+an active project.  Contribtors are welcome!
+
+## Conventions
+
+We have established a few conventions about decision tasks. These are based on
+our experience with Gecko, and will help avoid some pitfalls we encountered.
+They will also ensure that your decision tasks are compatible with any later
+formalisms we may add around decision tasks.
+
+ * A decision task is the first task in a task group, and that task group's
+   `taskGroupId` is identical to its `taskId`. As a corollary, it is easy to
+   find the decision task for a subtask: simply treat its `taskGroupId` as a
+   `taskId`.
+
+ * Decision tasks call `queue.createTask` using the taskclusterProxy feature,
+   meaning that no TaskCluster credentials are required, and the scopes
+   available for the `createTask` call are those afforded to the decision task
+   itself.
+
+ * A decision task runs with all of the scopes that any task it creates might
+   need. It calculates precisely the scopes each subtask requires, and supplies
+   those to the `queue.createTask` call.
+ 
+ * All subtasks depend on the decision task. This ensures that, if the decision
+   task crashes after having created only some of the subtasks, none of those
+   tasks run and the decision task can simply be re-triggered.


### PR DESCRIPTION
This adds a manual page for hooks, and since I referred to them, a decision task.

taskcluster/taskcluster-hooks#35 takes care of making sure hooks produce a task with taskId === taskGroupId.