### PR TITLE
Add a "people of taskcluster" page to the docs

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var makeRedirects = require('./lib/make-redirects');
 var s3 = require('./lib/s3');
 var raw = require('./lib/raw');
 var download = require('gulp-download-stream');
+var userlist = require('./lib/userlist');
 
 
 // define streams creating each type of file
@@ -37,6 +38,17 @@ function resources() {
     .src('src/resources.md', {base: 'src'})
     .pipe(frontmatter({property: 'data'}))
     .pipe(markdown())
+    .pipe(filter.renameIndex())
+    .pipe(rename({extname: ''}))
+    .pipe(pug({template: 'layout/layout.pug'}))
+    .pipe(headers.set('Content-Type', 'text/html'))
+}
+
+function people() {
+  return gulp
+    .src('src/people.pug', {base: 'src'})
+    .pipe(frontmatter({property: 'data'}))
+    .pipe(userlist({template: 'layout/people.pug'}))
     .pipe(filter.renameIndex())
     .pipe(rename({extname: ''}))
     .pipe(pug({template: 'layout/layout.pug'}))
@@ -133,6 +145,7 @@ function site() {
   return merge(
     index(),
     resources(),
+    people(),
     error(),
     tutorial(),
     manual(),

--- a/lib/userlist.js
+++ b/lib/userlist.js
@@ -1,0 +1,69 @@
+"use strict";
+var gutil = require('gulp-util');
+var through = require('through2');
+var Mozillians = require('mozillians-client');
+var yaml = require('js-yaml');
+var pug = require('pug');
+
+// Take a file containing a PUG template, along with file.data.people containing
+// a list of mozillians usernames, and produce HTML output.
+module.exports = function (options) {
+  return through.obj(function (file, enc, cb) {
+    peoplePage(file.data.people, file.contents, options).then(contents => {
+      file.contents = contents;
+      file.path = gutil.replaceExtension(file.path, '.html');
+      cb(null, file);
+    }, err => {
+      console.log("err", err);
+      cb(err, null);
+    });
+  });
+};
+
+var peoplePage = (people, template, options) => {
+  var peoplePromise;
+  if (!process.env.MOZILLIANS_API_KEY) {
+    gutil.log('WARNING: $MOZILLIANS_API_KEY is not set; not generating mozillians links');
+    peoplePromise = Promise.resolve(people.map(username => ({username})));
+  } else {
+    // collect details from the Mozillians API
+    let mozillians = new Mozillians(process.env.MOZILLIANS_API_KEY, {});
+    peoplePromise = Promise.all(people.map(username =>
+      // fetch the user
+      mozillians.users({username})
+        .then(res => {
+          if (res.count !== 1) {
+            gutil.log('Mozillians user ' + username + ' not found - is the account public?');
+            return {username};
+          }
+          // fetch the user details
+          return res.results[0].details();
+        })
+        // filter out non-public details
+        .then(details => {
+          Object.keys(details).forEach(prop => {
+            var val = details[prop];
+            if (typeof val === "object" && 'privacy' in val && val.privacy !== 'Public') {
+              delete details[prop];
+            }
+            // values we don't have access to are usually empty
+            if (typeof val === 'object' && val.value === '') {
+              delete details[prop];
+            }
+          });
+          if (details.external_accounts) {
+            details.external_accounts = details.external_accounts.filter(
+                acct => acct.privacy !== 'Mozillians');
+          }
+          return details;
+        })
+    ));
+  }
+
+  return peoplePromise.then(people => {
+    var params = {
+      people,
+    };
+    return new Buffer(pug.render(template, params));
+  });
+};

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "merge-stream": "^1.0.0",
     "mime": "^1.3.4",
     "morgan": "^1.7.0",
+    "mozillians-client": "^0.1.1",
     "pixl-xml": "^1.0.9",
     "promise": "^6.1.0",
     "pug": "^2.0.0-alpha6",

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -405,3 +405,48 @@ h2 > p {
 .vg { color: #19177C } /* Name.Variable.Global */
 .vi { color: #19177C } /* Name.Variable.Instance */
 .il { color: #666666 } /* Literal.Number.Integer.Long */
+
+/* people page */
+.people-list {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-around;
+  align-items: top;
+  font-family: 'Open Sans',sans-serif;
+}
+
+.person {
+  padding: 5px;
+  margin: 5px;
+  text-align: center;
+  min-width: 200px;
+}
+
+.person .photo-frame {
+  width: 100px;
+  height: 100px;
+  margin: auto;
+}
+
+.person .photo-frame img {
+  border-radius: 100%;
+  background-clip: padding-box;
+  border: 3px solid white;
+  box-shadow: 0px 0px 5px rgba(2,2,2,0.2);
+  width: 100px;
+  height: 100px;
+  box-sizing: border-box;
+}
+
+.person h2 {
+  font-size: 17px;
+  font-weight: 200;
+  margin: 5px;
+}
+
+.person ul.contacts {
+  font-size: 11px;
+  list-style: none;
+  padding: 0;
+  margin: 0px 0px;
+}

--- a/src/index.md
+++ b/src/index.md
@@ -31,3 +31,9 @@ Refer to the [reference documentation](/reference) for the technical details of 
 ### <span class="glyphicon glyphicon-link" aria-hidden="true"></span> Resources
 
 See [resources](/resources) such as presentations, external services, and useful links used by and for TaskCluster.
+
+---
+
+### <span class="glyphicon glyphicon-heart" aria-hidden="true"></span> People
+
+Find out more about the [people](/people) who make TaskCluster, and get involved yourself!

--- a/src/people.pug
+++ b/src/people.pug
@@ -1,0 +1,57 @@
+---
+title: People of TaskCluster
+noAnchors: true
+people:
+ # These are mozillians usernames, and only public information appears in
+ # the site. Non-public Mozillians accounts will be hidden entirely. Add new
+ # people at the beginning so that they get top billing!
+ - lteigrob
+ - ayub.mohamed
+ - yannland
+ - t0xicCode
+ - ireneOwl
+ - kt
+ - andreadelrio
+ - anarute
+ - amiyaguchi
+ - chinmaykousik1
+ - akhtar.hammad
+ - reznord
+ - jonasfj
+ - eli
+ - jhford
+ - bstack
+ - helfi
+ - pmoore
+ - garndt
+ - wcosta
+ - dustin
+ - sdeckelmann
+---
+p
+  | TaskCluster is a Mozilla project, and we believe in working in an open, welcoming fashion.
+  | The people listed here have contributed to the TaskCluster project.
+  | Your name&nbsp;
+  a(href="https://wiki.mozilla.org/TaskCluster#Contributing")
+    | could be here, too!
+
+div.people-list
+  for person in people
+    .person
+      .photo-frame
+        a(href=person.url)
+          if person.photo
+            img.photo(src=person.photo['150x150'])
+          else
+            img.photo(src="https://www.gravatar.com/avatar/00000000000000000000000000000000?s=150")
+      a(href=person.url)
+        if person.full_name
+          h2.name #{person.full_name.value}
+        else
+          h2.name #{person.username}
+      ul.contacts
+        if person.ircname && person.ircname.length > 0
+          li IRC: #{person.ircname.value}
+        for acct in person.external_accounts || []
+          if acct.type === 'github'
+            li #{acct.name}: #{acct.identifier}<br/>


### PR DESCRIPTION
This is generated using public Mozillians API data.

I'm working with the Mozillians folks to find a better way to filter only public data, and I haven't set up the automatic builds yet, but I'll figure that out before I merge.  In the interim, if you want to see the results, you'll need to run it locally with your own Mozilians API key in `$MOZILLIANS_API_KEY`.

Note that a *lot* of the accounts this links to are non-public.  I was thinking of reaching out to the relevant people to let them know (a) you're in the credits and (b) private is fine, but if you want more detail included, consider making your profile public.