### PR TITLE
Add docker-exec-websocket-server to libraries list

### DIFF
--- a/src/reference/libraries/docker-exec-websocket-server/index.md
+++ b/src/reference/libraries/docker-exec-websocket-server/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/docker-exec-websocket-server/master/README.md'></div>

--- a/src/reference/libraries/ws-shell/index.md
+++ b/src/reference/libraries/ws-shell/index.md
@@ -1,0 +1,12 @@
+---
+layout:       default
+class:        html
+docson:       true
+marked:       true
+ejs:          true
+superagent:   true
+docref:       true
+docreadme:    true
+---
+
+<div data-doc-readme='https://raw.githubusercontent.com/taskcluster/ws-shell/master/README.md'></div>


### PR DESCRIPTION
The name has server in it, but this seems like the best place for it?