### PR TITLE
Clarify when to use roles vs. storing scopes

### DIFF
--- a/src/manual/devel/best-practices/scopes.md
+++ b/src/manual/devel/best-practices/scopes.md
@@ -12,6 +12,22 @@ However, when the operation modifies an object which will later perform actions 
 For example, hooks trigger tasks using role `hook-id:<hookGroupId>/<hookId>`, so the API calls to create and modify the hook require `assume:hook-id:<hookGroupId>/<hookId>` directly.
 It is not enough simply to possess the role's extended scopes -- the caller must possess the assumed role itself.
 
+## Persisting Scopes in Resource
+
+When modifying or creating a resource that will later perform actions on behavor of the _resource creator_,
+the scopes delegated by the resource creator should be explicitly specified and saved in the resource.
+For example, a task can perform actions on behalf of the _task creator_, however, the scopes delegated to the
+task must be explicitly given in `task.scopes`. The service (in the case the queue) is naturally responsible
+verifying that the task creator possesses the scopes specified in `task.scopes`.
+
+Services should generally prefer to avoid storing lists of scopes in resources. It makes sense to store a list of
+scopes in a temporary resources, such as a task which has a fixed deadline. For permanent resources like workers
+or hooks should not contain a list of assigned scopes. Instead they should encode their identity in a role and
+assume this role when performing actions. For example, a `workerType` in the aws-provisioner doesn't contain a
+list of assigned scopes, instead the workers assumes the role `worker-type:<provisionerId>/<workerType>`.
+
+Following this pattern for permanent resources ensures that any permanent grant of authority can be inspected through roles.
+
 ## Encoding Information In Roles
 
 Scopes should only ever be used to evaluate scope satisfaction; never pattern match scopes to try to extract information from them.


### PR DESCRIPTION
I think we're pretty good at following this rule.. But it's worth writing down, along with it's obvious exceptions like short-live resources..