### PR TITLE
Bug 1390350 - Can't click menu items when window is too narrow

### DIFF
--- a/layout/layout.pug
+++ b/layout/layout.pug
@@ -11,7 +11,7 @@ html(lang='en')
             hr
           aside#sidebar.col-md-3.col-xs-12.hidden-sm.hidden-xs
             include sidebar.pug
-          section#content.col-md-9
+          section#content.col-md-9.col-xs-12
             if title
               h1 !{title}
               hr


### PR DESCRIPTION
On smaller screens, the content was overlapping with the menu list (you'll need the dev-tools inspector to see the overlap). This fixes the issue