### PR TITLE
Force publishing on push

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -181,9 +181,16 @@ gulp.task('webserver', function() {
 
 gulp.task('publish', function() {
   return s3.makePublisher().then(function(publisher) {
+    var publishOptions = {
+      // don't try to set x-amz-acl, as we don't have permission
+      noAcl: true,
+      // force writing all files if PUBLISH_FORCE is set (this avoids
+      // caching issues in gulp-awspublish around header-only changes)
+      force: !!process.env['PUBLISH_FORCE']
+    };
     return site()
       .pipe(s3.setHeaders())
-      .pipe(parallelize(publisher.publish({}, {noAcl: true}), 20))
+      .pipe(parallelize(publisher.publish({}, publishOptions), 20))
       .pipe(publisher.cache())
       .pipe(awspublish.reporter())
   });

--- a/util/taskcluster-build.sh
+++ b/util/taskcluster-build.sh
@@ -14,9 +14,11 @@ if [ "$1" = "pull-request" ]; then
         echo "Pull Request contains incorrect capitalization of Taskcluster; see above"
         exit 1
     fi
-elif [ "$1" = "push" ]; then
+elif [ "$1" = "push" ] || [ $1 = "hook" ]; then
     export PUBLISH_BUCKET=docs-taskcluster-net
     export PUBLISH_REGION=us-west-2
+    # for pushes, force update, since subtle things may have changed..
+    [ $1 = "push" ] && export PUBLISH_FORCE=yes
     export MOZILLIANS_SECRET=project/taskcluster/tc-docs/mozillians
     yarn deploy
 fi


### PR DESCRIPTION
The idea is to modify the hook to pass "hook" instead of "push" once this lands.