### PR TITLE
Remove some detail on clients, scopes, roles

### DIFF
--- a/src/manual/design/apis/hawk/clients.md
+++ b/src/manual/design/apis/hawk/clients.md
@@ -6,16 +6,12 @@ order: 23
 
 Taskcluster authentication begins with "clients". Each client has a name
 (`clientId`) and a secret access token. These can be used together to make API
-requests to Taskcluster services.
+requests to Taskcluster services. Each client has a set of scopes associated
+with it, controlling what that client can do.
 
-Clients can be configured to expire on a specific date. An expired client is
-no longer recognized by Taskcluster services. Clients can also be disabled;
-this is used to prevent use of clients for which an associated user no longer
-has permission. Most users do not have permission to enable a client.
-
-Every client also has a set of [scopes](scopes). The client's scopes
-control the client's access to Taskcluster resources. The scopes are
-*expanded* by substituting roles, as defined in the [roles](roles) section.
+See [the taskcluster-auth
+docs](/reference/platform/taskcluster-auth/docs/clients) for more detailed
+information.
 
 The set of defined clients is visible in the [Clients
 tool](http://tools.taskcluster.net/auth/clients/). This interface helpfully

--- a/src/manual/design/apis/hawk/roles.md
+++ b/src/manual/design/apis/hawk/roles.md
@@ -9,28 +9,9 @@ constitutes a simple _expansion rule_ that says if you have the scope
 `assume:<roleId>` you get the set of scopes associated with the role named
 `roleId`. Roles can refer to other roles in the same way.
 
-
-## Stars in Roles
-
-As in scopes, a final `*` in a role ID acts as a wildcard. It matches any
-`assume` scope of which it is a prefix. For example, the role ID
-`repo:github.com/taskcluster/*` will match
-`assume:repo:github.com/taskcluster/taskcluster-auth`.
-
-When roles are concerned, stars expand in two ways:
-
- * (scope expansion) An `assume` scope ending in a star will satisfy any scope
-   implied by any role of which it is a prefix. For example, if role
-   `repo:github.com/taskcluster/taskcluster-auth` has scope
-   `secrets:get:auth-tests`, then credentials with scope
-   `assume:repo:github.com/taskcluster/*` can get the `auth-tests` secret.
-   This means that `assume:` scopes ending in a star can be very powerful!
-
- * (role expansion) A role ending in a star will apply to all roles of which it
-   is a prefix. For example, if role `hook:taskcluster/*` has scope
-   `queue:create-task:aws-provisioner/taskcluster-hooks`, then a credential
-   with `assume:hook:taskcluster/nightly-diagnostics` can create a task with
-   the `taskcluster-hooks` worker type.
+See [the taskcluster-auth
+docs](/reference/platform/taskcluster-auth/docs/roles) for more detailed
+information on roles and role expansion.
 
 ## In Practice
 

--- a/src/manual/design/apis/hawk/scopes.md
+++ b/src/manual/design/apis/hawk/scopes.md
@@ -14,43 +14,6 @@ of this manual. Note that some API endpoints may have additional scope
 requirements that depend on the body of the request; read the endpoint
 documentation carefully to discover these.
 
-## Scopes
-
-A scope is simply a string, limited to printable ASCII characters. Scopes
-generally travel in sets. For example, a typical client will have a set of a
-few dozen scopes.
-
-## Satisfaction
-
-A set of scopes A is said to "satisfy" another set of scopes B if every scope
-in B is also in A. In a practical sense, A is often the set of scopes
-associated with some Taskcluster credentials, and B is the set of scopes
-required by an API call. If A satisfies B, then the call is permitted.
-
-The more mathematically inclined may like to think of this as a subset
-relationship: B ⊆ A.
-
-There is one piece of special syntax in scopes: a final `*` character acts as a
-wildcard, matching any suffix. So `queue:create-task:test-provisioner/*`
-satisfies `queue:create-task:test-provisioner/worker3`. The reverse is not
-true. The wildcard only works at the end of a string: no more advanced
-pattern-matching functionality is available.
-
-Even so, this is an incredibly powerful technique, as all of the scopes
-required by Taskcluster services have been carefully designed with
-more-specific attributes on to the right of less-specific attributes.
-
-## But I Thought Scopes Were Crazy Complicated?
-
-Nope, that's all there is to it!
-
-Here are a few examples:
-
-The scope set `["queue:create-task:aws-provisioner-v1/*",
-"queue:route:index.project.persona.*"]` satisfies the scope set
-`["queue:create-task:aws-provisioner-v1/persona-builder",
-"queue:route:index.project.persona.build.20160101.linux64"]`.
-
-The scope set `["secrets:get:garbage/*", "queue:create-task:*"]` satisfies the
-scope set `["secrets:get:garbage/my/secret",
-"secrets:get:garbage/your/secret"]`.
+See [the taskcluster-auth
+docs](/reference/platform/taskcluster-auth/docs/scopes) for more detailed
+information on scopes, scope satisfaction, and stars in scopes.


### PR DESCRIPTION
This detail is [now included](https://github.com/taskcluster/taskcluster-auth/pull/113) in the tc-auth reference pages, closer to
where it is implemented.