### PR TITLE
Sync files with s3 and skip cacheing since we don't use it anyway

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -199,7 +199,7 @@ gulp.task('publish', function() {
     return site()
       .pipe(s3.setHeaders())
       .pipe(parallelize(publisher.publish({}, publishOptions), 20))
-      .pipe(publisher.cache())
+      .pipe(publisher.sync())
       .pipe(awspublish.reporter())
   });
 });


### PR DESCRIPTION
I believe this will fix our woes with s3 being filled with cruft.