### PR TITLE
Bug 1415868 - docs for actions with kind=hook

### DIFF
--- a/src/manual/using/actions/guidelines.md
+++ b/src/manual/using/actions/guidelines.md
@@ -1,0 +1,40 @@
+---
+title: Implementation Guidelines
+order: 10
+---
+
+### Choosing a Kind
+
+The "task" kind requires that the user invoking the task has all of the scopes
+necessary to run the action task (and to create any further tasks). Granting
+such scopes allows a user to perform undesirable actions with the Taskcluster
+API.
+
+The "hook" kind allows more control over users' permissions. The key
+observation is that `hooks.triggerHook` is governed by a scope of the form
+`hooks:trigger-hook:<hookGroupId>/<hookId>`, but the task it creates uses role
+`hook-id:<hookGroupId>/<hookId>`. The method also verifies its payload against
+the hook's `triggerSchema`.  This allows a controlled privilege escalation:
+only clients with the appropriate `trigger-hook` scope may trigger a hook, and
+only if they provide a payload matching the `triggerSchema`. If both of those
+conditions are met, then the resulting task may execute with permissions the
+originating client does not posses.
+
+To design a hook-based action, start with the hook and consider the minimal
+inputs that it requires. For example, a hook to re-trigger a task with
+`DEBUG=*` needs only a taskId. Construct the hook with a `triggerSchema`
+allowing only those minimal inputs in an appropriate form (avoiding quoting
+vulnerabilities), and if possible add additional checks within the task itself
+-- for example, check that the task to be re-triggered has the expected
+schedulerId, workerType and provsionerId,
+
+Then consider who should be allowed to trigger the hook, and distribute the
+`hooks:trigger-hook` scope accordingly. Note that even if this scope is
+available only to a few users or clients, it is best to limit inputs carefully
+to avoid those users being "tricked" into running a malicious action.
+
+Once the hook is complete and functional, only then should you design the
+`actions.json` entry to trigger it.  At this point you should remember that the
+schema is only for documentation, and you cannot rely on the integrity of
+`actions.json`.  A "hook" action is just a template for how to call
+`hooks.triggerHook` and does not offer any level of security.

--- a/src/manual/using/actions/schema.yml
+++ b/src/manual/using/actions/schema.yml
@@ -10,6 +10,46 @@ description: |
   defined by `public/actions.json`. A _consumer_ might be Treeherder.
   The _end-user_ is a developer who is inspecting the results, and wishes to
   trigger actions.
+definitions:
+  name:
+    type: string
+    maxLength: 255
+    description: |
+      The name of this action.  This is used by user interfaces to
+      identify the action.
+  title:
+    type: string
+    maxLength: 255
+    description: |
+      Title text to be displayed on the button or link triggering the action.
+  description:
+    type: string
+    maxLength: 4096
+    description: |
+      Human readable description of the action in markdown. This
+      can be displayed in a tooltip, popup and/or dialog when triggering
+      the action.
+  context:
+    type: array
+    default: []
+    items:
+      type: object
+      additionalProperties:
+        type: string
+        maxLength: 4096
+      title: tag-set
+      description: |
+        A set of key-value pairs specifying a _tag-set_.
+    description: |
+      The `context` property determines in what context the action is
+      relevant. Thus, what context the action should be presented to the
+      end-user.
+  schema:
+    $ref: http://json-schema.org/schema
+    description: |
+      JSON schema for user input to the action.  If this property is omitted,
+      then the input is `null`.
+
 type: object
 properties:
   version:
@@ -25,116 +65,71 @@ properties:
     description: |
       List of actions that can be triggered.
     items:
-      allOf:
-        # Properties common to all actions
-        - type: object
-          properties:
-            name:
-              type: string
-              maxLength: 255
-              description: |
-                The name of this action.  This is used by user interfaces to
-                identify the action.
-            title:
-              type: string
-              maxLength: 255
-              description: |
-                Title text to be displayed on the button or link triggering the action.
-            description:
-              type: string
-              maxLength: 4096
-              description: |
-                Human readable description of the action in markdown. This
-                can be displayed in a tooltip, popup and/or dialog when triggering
-                the action.
-            kind:
-              enum:
-                - task
-                - hook
-              description: |
-                Specifies the kind of action this is.
-            context:
-              type: array
-              default: []
-              items:
-                type: object
-                additionalProperties:
-                  type: string
-                  maxLength: 4096
-                title: tag-set
-                description: |
-                  A set of key-value pairs specifying a _tag-set_.
-              description: |
-                The `context` property determines in what context the action is
-                relevant. Thus, what context the action should be presented to the
-                end-user.
-            schema:
-              $ref: http://json-schema.org/schema
-              description: |
-                JSON schema for user input to the action.  If this property is omitted,
-                then the input is `null`.
-          additionalProperties: true
-          required:
-            - title
-            - description
-            - kind
+      anyOf:
+      - type: object
+        properties:
+          kind: {enum: [task]}
+          name: {$ref: '#/definitions/name'}
+          title: {$ref: '#/definitions/title'}
+          description: {$ref: '#/definitions/description'}
+          context: {$ref: '#/definitions/context'}
+          schema: {$ref: '#/definitions/schema'}
+          task:
+            type: object
+            title: Task Template
+            description: |
+              Task template for triggering the action.
 
-        # Properties specific to each kind
-        - anyOf:
-          - type: object
-            properties:
-              kind: task
-              task:
-                type: object
-                title: Task Template
-                description: |
-                  Task template for triggering the action.
+              When an action have been selected in the appropriate context and
+              input satisfying the `schema` (if any) has been collected. The
+              action is triggered by parameterizing the task template given in
+              this property, and creating the resulting task.
 
-                  When an action have been selected in the appropriate context and
-                  input satisfying the `schema` (if any) has been collected. The
-                  action is triggered by parameterizing the task template given in
-                  this property, and creating the resulting task.
+              The template is an object that is parameterized using
+              [JSON-e](https://github.com/taskcluster/json-e), with the context
+              described in the documentation.
+        additionalProperties: false
+        required:
+          - kind
+          - title
+          - description
+          - task
+      - type: object
+        properties:
+          kind: {enum: [hook]}
+          name: {$ref: '#/definitions/name'}
+          title: {$ref: '#/definitions/title'}
+          description: {$ref: '#/definitions/description'}
+          context: {$ref: '#/definitions/context'}
+          schema: {$ref: '#/definitions/schema'}
+          hookGroupId:
+            type: string
+            title: Hook Group ID
+            description: The `hookGroupId` of the hook to trigger to run this action
+          hookId:
+            type: string
+            title: Hook ID
+            description: The `hookId` of the hook to trigger to run this action
+          hookPayload:
+            type: object
+            title: Hook Payload Template
+            description: |
+              JSON-e template that renders to the payload for `hooks.triggerHook`.
 
-                  The template is an object that is parameterized using
-                  [JSON-e](https://github.com/taskcluster/json-e), with the context
-                  described in the documentation.
-            additionalProperties: false
-            required:
-              - title
-              - description
-              - kind
-              - task
-          - type: object
-            properties:
-              kind: hook
-              hookGroupId:
-                type: string
-                title: Hook Group ID
-                description: The `hookGroupId` of the hook to trigger to run this action
-              hookId:
-                type: string
-                title: Hook ID
-                description: The `hookId` of the hook to trigger to run this action
-              hookPayload:
-                type: object
-                title: Hook Payload Template
-                description: |
-                  JSON-e template that renders to the payload for `hooks.triggerHook`.
-
-                  The template is an object that is parameterized using
-                  [JSON-e](https://github.com/taskcluster/json-e), with the
-                  context described in the documentation. The output of this
-                  rendering is provided as the payload to `hooks.triggerHook`
-                  (where it becomes the context for another JSON-e rendering
-                  step - don't get the two confused!)
-            additionalProperties: false
-            required:
-              - title
-              - description
-              - kind
-              - hookGroupId
-              - hookId
-              - hookPayload
+              The template is an object that is parameterized using
+              [JSON-e](https://github.com/taskcluster/json-e), with the
+              context described in the documentation. The output of this
+              rendering is provided as the payload to `hooks.triggerHook`
+              (where it becomes the context for another JSON-e rendering
+              step - don't get the two confused!)
+        additionalProperties: false
+        required:
+          - kind
+          - title
+          - description
+          - hookGroupId
+          - hookId
+          - hookPayload
 
 additionalProperties: false
 required:

--- a/src/manual/using/actions/schema.yml
+++ b/src/manual/using/actions/schema.yml
@@ -8,7 +8,7 @@ description: |
   For the purpose of this document the _consumer_ is the user-interface that
   displays task results to the end-user and allows end-users to trigger actions
   defined by `public/actions.json`. A _consumer_ might be Treeherder.
-  The _end-user_ is a developer who is inspecting the results, and wish to
+  The _end-user_ is a developer who is inspecting the results, and wishes to
   trigger actions.
 type: object
 properties:
@@ -18,19 +18,7 @@ properties:
   variables:
     type: object
     description: |
-      Mapping from variable name to constants that can be referenced using
-      `{$eval: '<variable>'}` within the task templates defined for each action.
-
-      This is useful for commonly used constants that are used in many task
-      templates. Whether it's to reduce the size of the `public/actions.json`
-      artifact by reuseing large constants, or simply to make it easier to
-      write task templates by exposing additional variables.
-
-      These will overwrite any builtin variables, such as `taskGroupId`,
-      `input`, `taskId`, `task`, and any further variables that future
-      backwards compatible iterations of this specifcation adds. Hence, you
-      should avoid declaring variables such as `input`, as it will shadow the
-      builtin `input` variable.
+      Additional variables included in JSON-e context.
     additionalProperties: true
   actions:
     type: array
@@ -44,15 +32,7 @@ properties:
           maxLength: 255
           description: |
             The name of this action.  This is used by user interfaces to
-            identify the action. For example, a retrigger button might look for
-            an action with `name = "retrigger"`.
-
-            Action names must be unique for a given task, or for a taskgroup,
-            but the same name may be used for actions applying to disjoint sets
-            of tasks. For example, it may be helpful to define different
-            "retrigger" actions for build tasks `[{jobKind: 'build'}]` and test
-            tasks `[{jobKind: 'test'}]`, and in this case only one such action
-            would apply to any given task.
+            identify the action. 
         title:
           type: string
           maxLength: 255
@@ -62,20 +42,14 @@ properties:
           type: string
           maxLength: 4096
           description: |
-            Human readable description of the action in markdown.
-            Can be displayed in tooltip, popup and/or dialog when triggering
+            Human readable description of the action in markdown. This
+            can be displayed in a tooltip, popup and/or dialog when triggering
             the action.
         kind:
           enum:
             - task
           description: |
             Specifies the kind of action this is.
-
-            The `task` _action kind_ is triggered by creating a task, following
-            a task template.
-
-            Other kinds might be added in the future. Consumers should ignore
-            all entries featuring a `kind` property they don't recognize.
         context:
           type: array
           default: []
@@ -91,64 +65,11 @@ properties:
             The `context` property determines in what context the action is
             relevant. Thus, what context the action should be presented to the
             end-user.
-
-            The `context` property contains a set of tag-sets. A _tag-set_ is a
-            set of key-value pairs. A task is said satisfy a tag-set if
-            `task.tags` is a super-set of the given tag-set. An action is
-            relevant for a task if the task satisfies at-least one of
-            the tag-sets.
-
-            Hence, an action with `context: [{a: '1'}, {b: '2'}]` is relevant
-            for any task with `task.tags.a = '1'` or `task.tags.b = '2'`.
-            An action with `context: [{a: '1', b: '2'}]` is only relevant for
-            tasks with `task.tags.a = '1'` and `task.tags.b = '2'`.
-
-            This allows restrictions of what tasks an action is relevant for.
-            For example some tasks might not support running under a debugger.
-
-            The keen reader observes that actions with `context: [{}]` are
-            relevant for all tasks. Conversely, we have that tasks with
-            `context: []` are irrelevant for all tasks. We abuse this property
-            and define actions with `context: []` to be relevant for the
-            _task-group_ only.
-
-            That is an action with `context: []` should not be display in the
-            context-sensitive menu for a task, rather it should be display when
-            selecting the entire task-group. Presentation details are left for
-            consumer to decide.
-
-            Notice that the `context` property is optional, but defined to have
-            a default value `context: []`. Hence, if the `context` is not
-            specified consumer should take this to mean `context: []` implying
-            that the action is relevant to the task-group, rather than any
-            subset of tasks.
         schema:
           $ref: http://json-schema.org/schema
           description: |
-            JSON schema for input parameters to the `task` template property.
-            Consumers shall offer a user-interface where end-users can enter
-            values that satisfy this schema. Furthermore, consumers **must**
-            validate enter values against the given schema before parameterizing
-            the `task` template property and triggering the action.
-
-            In practice it's encourage that consumers employ a facility that
-            can generate HTML forms from JSON schemas. However, if certain
-            schemas are particularly complicated or common, consumers may also
-            hand-write a user-interface for collecting the input. In this case
-            the consumer **must** do a deep comparison between the schema given
-            in the action, and the schema for which a custom user-interface have
-            been written, and fall-back to an auto-generated form if the schema
-            doesn't match.
-
-            It is assumed that the JSON schema `description` property will be
-            rendered as markdown when displayed as documentation for end-users.
-            Producers of `public/actions.json` is encouraged to provide a
-            detailed explanation of the input parameters using these
-            `description` properties. And consumers are *strongly* encouraged
-            to render `description` values as markdown.
-
-            The `schema` property is optional, and if not given the input for
-            `task` template parameterization shall be `null`.
+            JSON schema for user input to the action.  If this property is omitted,
+            then the input is `null`.
         task:
           type: object
           title: task template
@@ -161,11 +82,8 @@ properties:
             this property, and creating the resulting task.
 
             The template is an object that is parameterized using
-            [JSON-e](https://github.com/taskcluster/json-e), with the above
-            variables supplied as context.
-
-            This allows for dumping `input` and `taskId` into environment
-            variables for the task to be created. 
+            [JSON-e](https://github.com/taskcluster/json-e), with the context
+            described in the documentation.
       additionalProperties: false
       required:
         - title

--- a/src/manual/using/actions/schema.yml
+++ b/src/manual/using/actions/schema.yml
@@ -25,71 +25,117 @@ properties:
     description: |
       List of actions that can be triggered.
     items:
-      type: object
-      properties:
-        name:
-          type: string
-          maxLength: 255
-          description: |
-            The name of this action.  This is used by user interfaces to
-            identify the action. 
-        title:
-          type: string
-          maxLength: 255
-          description: |
-            Title text to be displayed on the button or link triggering the action.
-        description:
-          type: string
-          maxLength: 4096
-          description: |
-            Human readable description of the action in markdown. This
-            can be displayed in a tooltip, popup and/or dialog when triggering
-            the action.
-        kind:
-          enum:
-            - task
-          description: |
-            Specifies the kind of action this is.
-        context:
-          type: array
-          default: []
-          items:
-            type: object
-            additionalProperties:
+      allOf:
+        # Properties common to all actions
+        - type: object
+          properties:
+            name:
+              type: string
+              maxLength: 255
+              description: |
+                The name of this action.  This is used by user interfaces to
+                identify the action.
+            title:
+              type: string
+              maxLength: 255
+              description: |
+                Title text to be displayed on the button or link triggering the action.
+            description:
               type: string
               maxLength: 4096
-            title: tag-set
-            description: |
-              A set of key-value pairs specifying a _tag-set_.
-          description: |
-            The `context` property determines in what context the action is
-            relevant. Thus, what context the action should be presented to the
-            end-user.
-        schema:
-          $ref: http://json-schema.org/schema
-          description: |
-            JSON schema for user input to the action.  If this property is omitted,
-            then the input is `null`.
-        task:
-          type: object
-          title: task template
-          description: |
-            Task template for triggering the action.
+              description: |
+                Human readable description of the action in markdown. This
+                can be displayed in a tooltip, popup and/or dialog when triggering
+                the action.
+            kind:
+              enum:
+                - task
+                - hook
+              description: |
+                Specifies the kind of action this is.
+            context:
+              type: array
+              default: []
+              items:
+                type: object
+                additionalProperties:
+                  type: string
+                  maxLength: 4096
+                title: tag-set
+                description: |
+                  A set of key-value pairs specifying a _tag-set_.
+              description: |
+                The `context` property determines in what context the action is
+                relevant. Thus, what context the action should be presented to the
+                end-user.
+            schema:
+              $ref: http://json-schema.org/schema
+              description: |
+                JSON schema for user input to the action.  If this property is omitted,
+                then the input is `null`.
+          additionalProperties: true
+          required:
+            - title
+            - description
+            - kind
 
-            When an action have been selected in the appropriate context and
-            input satisfying the `schema` (if any) has been collected. The
-            action is triggered by parameterizing the task template given in
-            this property, and creating the resulting task.
+        # Properties specific to each kind
+        - anyOf:
+          - type: object
+            properties:
+              kind: task
+              task:
+                type: object
+                title: Task Template
+                description: |
+                  Task template for triggering the action.
 
-            The template is an object that is parameterized using
-            [JSON-e](https://github.com/taskcluster/json-e), with the context
-            described in the documentation.
-      additionalProperties: false
-      required:
-        - title
-        - description
-        - kind
-        - task
+                  When an action have been selected in the appropriate context and
+                  input satisfying the `schema` (if any) has been collected. The
+                  action is triggered by parameterizing the task template given in
+                  this property, and creating the resulting task.
+
+                  The template is an object that is parameterized using
+                  [JSON-e](https://github.com/taskcluster/json-e), with the context
+                  described in the documentation.
+            additionalProperties: false
+            required:
+              - title
+              - description
+              - kind
+              - task
+          - type: object
+            properties:
+              kind: hook
+              hookGroupId:
+                type: string
+                title: Hook Group ID
+                description: The `hookGroupId` of the hook to trigger to run this action
+              hookId:
+                type: string
+                title: Hook ID
+                description: The `hookId` of the hook to trigger to run this action
+              hookPayload:
+                type: object
+                title: Hook Payload Template
+                description: |
+                  JSON-e template that renders to the payload for `hooks.triggerHook`.
+
+                  The template is an object that is parameterized using
+                  [JSON-e](https://github.com/taskcluster/json-e), with the
+                  context described in the documentation. The output of this
+                  rendering is provided as the payload to `hooks.triggerHook`
+                  (where it becomes the context for another JSON-e rendering
+                  step - don't get the two confused!)
+            additionalProperties: false
+            required:
+              - title
+              - description
+              - kind
+              - hookGroupId
+              - hookId
+              - hookPayload
+
 additionalProperties: false
 required:
   - version

--- a/src/manual/using/actions/spec.md
+++ b/src/manual/using/actions/spec.md
@@ -281,6 +281,39 @@ Note that the result of rendering `hookPayload` becomes the context for another
 JSON-e rendering performed by the hooks service.  Do not confuse the two
 operations!
 
+### Choosing a Kind
+
+The "task" kind requires that the user invoking the task has all of the scopes
+necessary to run the action task (and to create any further tasks). Such scopes
+might allow a user to perform undesirable actions with the Taskcluster API.
+
+The "hook" kind allows more control over users' permissions. The key
+observation is that `hooks.triggerHook` is governed by a scope of the form
+`hooks:trigger-hook:<hookGroupId>/<hookId>`, but the task it creates uses role
+`hook-id:<hookGroupId>/<hookId>`. The method also verifies its payload against
+the hook's `triggerSchema`.  This allows a controlled privilege escalation:
+only clients with the appropriate `trigger-hook` scope may trigger a hook, and
+only if they provide a payload matching the schema. If both of those conditions
+are met, then the resulting task may execute with permissions the originating
+client does not posses.
+
+To design a hook-based action, start with the hook and consider the minimal
+inputs that it requires. For example, a hook to re-trigger a task with
+`DEBUG=*` needs only a taskId. Construct the hook with a `triggerSchema`
+allowing only those minimal inputs in an appropriate form (avoiding quoting
+vulnerabilities), and if possible add additional checks within the task itself
+-- for example, check that the task to be re-triggered has the expected
+schedulerId, workerType and provsionerId,
+
+Then consider who should be allowed to trigger the hook, and distribute the
+`hooks:trigger-hook` scope accordingly. Note that even if this scope is
+available only to a few users or clients, it is best to limit inputs carefully
+to avoid those users being "tricked" into running a malicious action.
+
+Once the hook is complete and functional, only then should you design the
+`actions.json` entry to trigger it. An "hook" action is just a template for how
+to call `hooks.triggerHook` and does not offer any level of security.
+
 ## Formal Specification
 
 The JSON Schema for `actions.json` is as follows, also available in raw form

--- a/src/manual/using/actions/spec.md
+++ b/src/manual/using/actions/spec.md
@@ -1,6 +1,6 @@
 ---
 title: Action Specification
-order: 1
+order: 20
 ---
 
 This document specifies how actions exposed by the *[decision
@@ -159,7 +159,7 @@ When writing schemas it is strongly encouraged that the JSON schema
 is assumed that consumers will render these `description` properties as
 markdown.
 
-In practice it's encourage that consumers employ a facility that can generate
+In practice it's encouraged that consumers employ a facility that can generate
 HTML forms from JSON schemas. However, if certain schemas are particularly
 complicated or common, consumers may also hand-write a user-interface for
 collecting the input. In this case the consumer **must** do a deep comparison
@@ -280,39 +280,6 @@ is rendered using JSON-e with the context described above.
 Note that the result of rendering `hookPayload` becomes the context for another
 JSON-e rendering performed by the hooks service.  Do not confuse the two
 operations!
-
-### Choosing a Kind
-
-The "task" kind requires that the user invoking the task has all of the scopes
-necessary to run the action task (and to create any further tasks). Such scopes
-might allow a user to perform undesirable actions with the Taskcluster API.
-
-The "hook" kind allows more control over users' permissions. The key
-observation is that `hooks.triggerHook` is governed by a scope of the form
-`hooks:trigger-hook:<hookGroupId>/<hookId>`, but the task it creates uses role
-`hook-id:<hookGroupId>/<hookId>`. The method also verifies its payload against
-the hook's `triggerSchema`.  This allows a controlled privilege escalation:
-only clients with the appropriate `trigger-hook` scope may trigger a hook, and
-only if they provide a payload matching the schema. If both of those conditions
-are met, then the resulting task may execute with permissions the originating
-client does not posses.
-
-To design a hook-based action, start with the hook and consider the minimal
-inputs that it requires. For example, a hook to re-trigger a task with
-`DEBUG=*` needs only a taskId. Construct the hook with a `triggerSchema`
-allowing only those minimal inputs in an appropriate form (avoiding quoting
-vulnerabilities), and if possible add additional checks within the task itself
--- for example, check that the task to be re-triggered has the expected
-schedulerId, workerType and provsionerId,
-
-Then consider who should be allowed to trigger the hook, and distribute the
-`hooks:trigger-hook` scope accordingly. Note that even if this scope is
-available only to a few users or clients, it is best to limit inputs carefully
-to avoid those users being "tricked" into running a malicious action.
-
-Once the hook is complete and functional, only then should you design the
-`actions.json` entry to trigger it. An "hook" action is just a template for how
-to call `hooks.triggerHook` and does not offer any level of security.
 
 ## Formal Specification
 

--- a/src/manual/using/actions/spec.md
+++ b/src/manual/using/actions/spec.md
@@ -267,6 +267,20 @@ Actions of the `'task'` *kind* **must** have a `task` property. This
 property specifies the task template to be parameterized and created in
 order to trigger the action.
 
+### "hook" kind
+
+An action with `kind: 'hook'` specifies a hook that should be triggered
+via the `hooks.triggerHook` API method when the action is executed.
+
+The hook is specified in the `hookId` and `hookGroupId` properties.
+
+The payload of the hook is given by the `hookPayload` property, which
+is rendered using JSON-e with the context described above.
+
+Note that the result of rendering `hookPayload` becomes the context for another
+JSON-e rendering performed by the hooks service.  Do not confuse the two
+operations!
+
 ## Formal Specification
 
 The JSON Schema for `actions.json` is as follows, also available in raw form

--- a/src/manual/using/actions/ui.md
+++ b/src/manual/using/actions/ui.md
@@ -21,11 +21,16 @@ Every user interface should support the following:
     auto-generated from the action's JSON-schema. If the action has no
     schema, this step should be skipped. The user's input should be
     validated against the schema.
--   For `action.kind = 'task'`, rendering the template using the
-    JSON-e library, using the variables described in action-spec.
+
+For `action.kind = 'task'`:
+
+-   Rendering the template using the JSON-e library, using the JSON-e
+    context described in action-spec.
 -   Calling `Queue.createTask` with the resulting task, using the
     user's Taskcluster credentials. See the next section for some
     important security-related concerns.
+
+User interfaces should ignore actions with unrecognized kinds.
 
 Creating Tasks
 --------------

--- a/src/manual/using/actions/ui.md
+++ b/src/manual/using/actions/ui.md
@@ -1,6 +1,6 @@
 ---
 title: User Interface Considerations
-order: 2
+order: 30
 ---
 
 The actions system decouples in-tree changes from user interface changes
@@ -67,6 +67,13 @@ decision task couldn't do.
 Instead, the user interface should require the user to confirm each action,
 displaying the hookGroupId, hookId, and hookPayload.
 
+Furthermore, hook implementations should be designed to guard against malicious
+input, which could be triggered by phishing an unsuspecting administrator to
+trigger a hook action from a low privileged task with bad intend, causing an
+evil hookPayload. The hook's `triggerSchema` can be one layer of such a guard,
+but the hook implementation itself should perform additional checks wherever
+possible.
+
 Specialized Behavior
 --------------------
 
@@ -122,6 +129,6 @@ process for hook actions if any of
 
 * it can limit the scopes available using
   [authorizedScopes](https://docs.taskcluster.net/manual/design/apis/hawk/authorized-scopes)
-  based on some other definiitve information about the task -- for example,
+  based on some other definitive information about the task -- for example,
   actions on a task not created from a Github "master" branch might use
   authorizedScopes to limit access to only pull-request-related actions.


### PR DESCRIPTION
You might want to take this commit-by-commit.

Mostly I'd like some thought and feedback on the security implications.  The risk is that someone makes a try job with the `retrigger` action configured to run hook `project-gecko/in-tree-action-3-relpromo` with a payload that promotes some malicious try build as Firefox 666.  Then some innocent test task turns orange on the try job and they kindly ask someone in releng or relman to click "retrigger" for that task.

My thinking is that a "generic" actions UI would run the user through two dialogs for an hook action:
 * Enter the task input so that it matches the schema
 * See and confirm the hookId, hookGroupId, and rendered payload
The first can be skipped if there's no schema, of course.

Treeherder, however, can do a bit better:
 * Use `authorizedScopes=['mozilla-group:scm_level_1']` for try, 2 for level-2 repos, etc.
 * For hard-wired things like 'r', check the hookGroupId/hookId
 * Do the two-phase confirmation for everything else.