### PR TITLE
Introduce project-grants

### DIFF
--- a/src/manual/design/namespaces.md
+++ b/src/manual/design/namespaces.md
@@ -120,6 +120,10 @@ Both are listed here:
    This role is then be assumed by the appropriate groups.
    See [administration](/manual/using/administration) for more information.
 
+* `project-grants:<project>/<grantName>` -
+   Roles on this form is used to grant additional scopes to a project, without
+   creating a role the project admin can modify.
+
 * `repo:<host>/<path>:branch:<branch>`,
   `repo:<host>/<path>:pull-request` -
    Roles of this form represent scopes available to version-control pushes and pull requests.

--- a/src/manual/design/namespaces.md
+++ b/src/manual/design/namespaces.md
@@ -21,9 +21,10 @@ request](https://github.com/taskcluster/taskcluster-docs).
 Most work at Mozilla falls into "projects", and these provide a nice
 organizational boundary for controlling access.  We use a consistent name for
 each project in the various namespaces below -- something simple and without
-punctuation.  The known projects can be seen in the [roles
-tool](https://tools.taskcluster.net/auth/roles/), with the prefix
-`project-admin`.
+punctuation.  The known projects can be seen by looking for scopes containing
+`project-admin:` using the [scope-explorer](https://tools.taskcluster.net/auth/scopes).
+
+To obtain a project file a _service request_ with your taskcluster administrator.
 
 ---
 
@@ -51,9 +52,9 @@ Client IDs have the following forms:
  * `static/*`, Clients with names prefixed `static/` are statically configured in the taskcluster deployment.
    They cannot be created, modified or deleted at runtime. These are used for bootstrapping services and creating
    initial clients and roles.
- 
+
  * `static/taskcluster/*`, Clients with the prefix `static/taskcluster/` are reserved for taskcluster services.
- 
+
  * `mozilla-ldap/<email>` -
    Clients with this name belong to users who have been authenticated against the Mozilla LDAP database.
    These are temporary credentials issued by [Taskcluster-Login](https://github.com/taskcluster/taskcluster-login).
@@ -149,10 +150,10 @@ Artifact names are, by convention, slash-separated.
 * `private/docker-worker/…` -
    Artifact names with this prefix are considered non-public, but access to them is otherwise quite broadly allowed to everybody with commit-level 1 access, regardless of NDA state.
 
-* `private/interactive/…` - 
-   Artifacts required to access interactive sessions, this prefix is considered non-public, but is made available to commit-level 1 users, contributors and community members. 
+* `private/interactive/…` -
+   Artifacts required to access interactive sessions, this prefix is considered non-public, but is made available to commit-level 1 users, contributors and community members.
 
-* `repo/<host>/<path>/…` - 
+* `repo/<host>/<path>/…` -
    Artifacts private to a specific repository, sub-scopes can be delegated through repository specific patterns.
 
 * `project/<project>/…` -

--- a/src/manual/design/namespaces.md
+++ b/src/manual/design/namespaces.md
@@ -121,8 +121,8 @@ Both are listed here:
    See [administration](/manual/using/administration) for more information.
 
 * `project-grants:<project>/<grantName>` -
-   Roles on this form is used to grant additional scopes to a project, without
-   creating a role the project admin can modify.
+   Roles on this form is used to grant additional scopes to the administrators of a project,
+   without creating a role the project administrators can modify.
 
 * `repo:<host>/<path>:branch:<branch>`,
   `repo:<host>/<path>:pull-request` -

--- a/src/manual/using/administration.md
+++ b/src/manual/using/administration.md
@@ -18,6 +18,7 @@ this role comes great power:
  * Manage the scope namespace `project:<project>:*`
  * Manage private artifacts beginning with `project/<project>/`
  * Manage secrets beginning with `project/<project>/`
+ * Assume roles `project-grants:<project>/*`
 
 Some other actions require help from the Taskcluster team; we are working on
 making administration more self-serve, but we are not there yet. File a bug in


### PR DESCRIPTION
The idea with `project-grants:<project>/<grantName>` is that the
project admins can't modify the role. Yet, they assume all these
roles via. a grant of `assume:project-grants:<..>/*` in `project-admin:*`.

This ensures that project admins can't modify the description of why
these scopes were granted to them. Also they can't accidentally delete
them.

It also makes it easy to list all the scopes we've granted to projects
that aren't part of the scopes normally granted to projects.

I propose that `grantName` is something descriptive, and that each grant
can contain multiple scopes. For example I create `project-grants:meao/github-repos`
that grants scopes like: `auth:{create|modify|delete}-role:repo:github.com/mozilla-more/*`.