### PR TITLE
Don't use mockSuite with expensive tests

### DIFF
--- a/src/manual/design/devel/best-practices/testing.md
+++ b/src/manual/design/devel/best-practices/testing.md
@@ -135,17 +135,11 @@ Some external dependencies are too expensive or complex to test against.
 For example, the AWS EC2 APIs are difficult to use in testing, and problems with tests could easily become very expensive.
 In such cases, it's OK to only test against mocks.
 
-In this case, use something like the following in your test suite, to indicate that real tests are not defined (note that these tests will always be skipped -- even with `$NO_TEST_SKIP` set):
+In this case, use something like the following in your test suite, using (mock) to indicate that these are against a mock.
+There are no tests against any "real" service, so there's nothing to skip.
 
 ```javascript
-secrets.mockSuite('spawning EC2 instances', [], function(mock) {
-  // testing instance spawning against the real EC2 service could be very expensive,
-  // so we never do it.
-  if (!mock) {
-    suiteSetup(function() {
-      this.skip();
-    }
-  }
+suite('spawning EC2 instances (mock)', function() {
   // ...
 });
 ```


### PR DESCRIPTION
I ran into this when thinking about how to test tc-login against auth0.  I don't think Mozilla has an environment that would allow it.  So there's no way to provide secrets, meaning that mockSuite will complain if NO_TEST_SKIP is set.  It's much simpler to just not try to *write* tests which would never run anyway.