### PR TITLE
Bug 1471205 - fix handling of relative $ref's

### DIFF
--- a/lib/raw.js
+++ b/lib/raw.js
@@ -134,7 +134,10 @@ module.exports = function() {
       }
       cb();
     }).catch(err => {
-      cb(err);
+      // cb(err) results in an unhandled Promise rejection, leaving the gulp run continuing.
+      // So, quit instead.
+      console.log(`While dereferencing schemas:\n${err.stack}`);
+      process.exit(1);
     });
   });
 }

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -85,7 +85,7 @@ module.exports = function() {
             if (schema.id) {
               schema.id = buildSchemaId(schema.id);
             }
-            return RefParser.dereference(schema, {
+            const deref = await RefParser.dereference(schema.$id || schema.id, schema, {
               resolve: {
                 taskcluster: {
                   order: 1,

--- a/lib/raw.js
+++ b/lib/raw.js
@@ -69,9 +69,8 @@ module.exports = function() {
       var dat = JSON.parse(file.contents);
       dat.marked = marked;
 
-      // TODO: Get this all cleaned up
-      await Promise.all(_.flatMap(dat.entries, ref => {
-        return _.map(['input', 'output', 'schema'], type => {
+      for (let ref of dat.entries) {
+        for (let type of ['input', 'output', 'schema']) {
           if (ref[type]) {
             let sname = ref[type].startsWith('http://') ?
               path.basename(url.parse(ref[type]).pathname) : // Old-style schema i.e. https://schemas.tc.net/...
@@ -107,13 +106,11 @@ module.exports = function() {
               dereference: {
                 circular: 'ignore',
               },
-            }).then(s => {
-              ref[type] = s;
             });
+            ref[type] = deref;
           }
-          return Promise.resolve();
-        });
-      }));
+        }
+      }
 
       file.contents = new Buffer(refTemplate(dat));
       file.inline = true;

--- a/lib/render-schemas.js
+++ b/lib/render-schemas.js
@@ -55,7 +55,7 @@ module.exports = () => through.obj((file, enc, cb) => {
           schema = fs.readFileSync(schemaPath);
         }
 
-        schema = await RefParser.dereference(JSON.parse(schema), {dereference: {circular: 'ignore'}});
+        schema = await RefParser.dereference(schemaRef, JSON.parse(schema), {dereference: {circular: 'ignore'}});
         schema.id = schema.id || schemaRef;
         schema.$id = schema.$id || schemaRef;
         div.innerHTML = template({schema, marked});


### PR DESCRIPTION
This was hard to track down because the API docs [do not make it clear that you can pass a base URI](https://github.com/BigstickCarpet/json-schema-ref-parser/issues/91).

This also hacks around the poor error handling (every time I try to actually solve it I get lost trying to figure out which streams API which libraries implement..) and serializes the ref processing so that failures don't happen concurrently with successes.