### PR TITLE
Bug 1472802 - for api schemas, always use local copies

### DIFF
--- a/lib/raw.js
+++ b/lib/raw.js
@@ -86,20 +86,30 @@ module.exports = function() {
             }
             const deref = await RefParser.dereference(schema.$id || schema.id, schema, {
               resolve: {
-                taskcluster: {
-                  order: 1,
-                  canRead: /^taskcluster:*/,
-                  read: (file, callback) => {
-                    let sname = url.parse(file.url).path.replace(/^\/schemas\/[^\/]*\//, '');
-                    callback(null, JSON.parse(fs.readFileSync(path.join('raw/reference', project, 'schemas', sname))));
-                  },
-                },
+                http: false,
+                file: false,
                 any: {
-                  order: 2,
-                  canRead: /^http*/,
+                  order: 1,
+                  canRead: /^http*|^taskcluster:/,
                   read: (file, callback) => {
-                    let sname = path.basename(url.parse(file.url).pathname);
-                    callback(null, JSON.parse(fs.readFileSync(path.join('raw/reference', project, 'schemas', sname))));
+                    const u = url.parse(file.url);
+                    let sname;
+                    if (u.hostname === 'schemas.taskcluster.net') {
+                      // e.g., https://schemas.taskcluster.net/hooks/v1/hook-definition.json -> strip /hooks/ from
+                      // the pathname
+                      sname = u.pathname.replace(/^\/[^\/]*\//, '');
+                    } else {
+                      // e.g., https://taskcluster.example.com/schemas/hooks/v1/hook-definition.json -> strip
+                      // /schemas/hooks/ from the pathname
+                      sname = u.pathname.replace(/^\/schemas\/[^\/]*\//, '');
+                    }
+
+                    // old services don't have a `v1/` in the filename..
+                    let filename = path.join('raw/reference', project, 'schemas', sname);
+                    if (!fs.existsSync(filename)) {
+                      filename = filename.replace('/v1/', '/');
+                    }
+                    callback(null, JSON.parse(fs.readFileSync(filename)));
                   },
                 },
               },


### PR DESCRIPTION
This is truly a mess, between old and new services.  I think a better
way to handle this would be to load all schemas -- everywhere -- and
index them by abstract $id, then dereference them.  But that sort of
load-everything approach is difficult and error-prone in gulp.