### PR TITLE
Link to `Using Taskcluster` page responds with a 404.

### DIFF
--- a/src/manual/index.md
+++ b/src/manual/index.md
@@ -46,5 +46,5 @@ The remainder of the manual describes the Taskcluster platform in depth.  The
 revolves -- tasks.  The [Task Execution chapter](/docs/manual/task-execution)
 describes how these tasks are executed.  The next chapter, [System
 Design](/docs/manual/system-design), provides the details you will need to interact
-with Taskcluster. Finally, [Using Taskcluster](/docs/manual/using/) presents a
+with Taskcluster. Finally, [Using Taskcluster](/docs/manual/using) presents a
 collection of common use cases and approaches to satisfy them.


### PR DESCRIPTION
If the link ends with a slash server is responding with a 404 error.
For `/docs/manual/using/` it's looking for
`/docs/manual/using/index.html` which doesn't exist.

This could be a server configuration issue, but it can be fixed with
this patch as well.