### PR TITLE
URL Rewriting for index (at documentation page).

### DIFF
--- a/layout/navbar.pug
+++ b/layout/navbar.pug
@@ -6,7 +6,7 @@ nav.navbar.navbar-default
         span.icon-bar
         span.icon-bar
         span.icon-bar
-      a.navbar-brand(href="/docs/")
+      a.navbar-brand(href="/docs")
         img(src="/docs/assets/taskcluster.svg")
         | TASKCLUSTER <span class="bullet">&bullet;</span> DOCS
     #navbar.collapse.navbar-collapse


### PR DESCRIPTION
Hello!
There is a bug when you click the logo at the navbar for redirecting to the index of the documentation section. When it tries to reach _/docs/_ it turns into a 404 because it cannot find any page to display, but if the href points to _/docs_ it resolves perfectly.
I know this is not exactly the way to report the issue and to propose the PR, but I think it's not a big deal that can be solved with this proposal. Anyhow, I'm sorry for not doing it in the right way and thanks for considering it!

Greetings :wave: